### PR TITLE
Fix bug while calculating the periods of a task related to the duration ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*~
+.*.swp
 COPYING
 Makefile
 Makefile.in

--- a/README.in
+++ b/README.in
@@ -4,8 +4,8 @@ README for rt-app @VERSION@
  INTRODUCTION
 ==============
 
-rt-app is a test application that starts multiple periodic threads in order to 
-simulate a real-time periodic load. It supports SCHED_OTHER, SCHED_FIFO, 
+rt-app is a test application that starts multiple periodic threads in order to
+simulate a real-time periodic load. It supports SCHED_OTHER, SCHED_FIFO,
 SCHED_RR as well as the AQuoSA framework and SCHED_DEADLINE.
 
 Code is currently maintained on GitHub:
@@ -74,7 +74,7 @@ Keep in mind that on commandline it will never be possible to define resources
 and how tasks access them.
 
 $ rt-app
-usage: rt-app [options] -t <period>:<exec>[:cpu affinity[:policy[:deadline[:prio]]]] 
+usage: rt-app [options] -t <period>:<exec>[:cpu affinity[:policy[:deadline[:prio]]]]
 
 -h, --help	:	show this help
 -f, --fifo	:	set default policy for threads to SCHED_FIFO

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ AC_ARG_WITH([aquosa],
               [Add support for the AQuoSA framework])],
             [],
             [with_aquosa=no])
-          
+
           QRESLIB=
           AS_IF([test "x$with_aquosa" != xno],
             [AC_CHECK_LIB([qreslib], [qres_init],
@@ -31,7 +31,7 @@ AC_ARG_WITH([aquosa],
               [-lqreslib])])
 
 AC_ARG_WITH([deadline],
-	[AS_HELP_STRING([--with-deadline], 
+	[AS_HELP_STRING([--with-deadline],
          [Add support for SCHED_DEADLINE])],
 	[],
 	[with_deadline=no])
@@ -46,17 +46,9 @@ AC_ARG_WITH([json],
 			   )
 	    ], [], [with_json=no]
 	   )
-LIBJSON=
 AS_IF([test "x$with_json" != "xno"],
-      [AC_CHECK_LIB([json], [json_object_from_file],
-	      	    [AC_SUBST([LIBJSON], ["-ljson"])
-        	     AC_DEFINE([JSON], [1], [Define if you have libjson])
-       	            ],
-       	            [AC_MSG_FAILURE([libjson test failed (use --without-json to disable or install json-c)])],
-                    [-ljson]
-		   )
-      ]
-     ) 
+        [PKG_CHECK_MODULES([LIBJSON], [json-c], [AC_DEFINE([JSON], [1], [Define if you have libjson])])
+     ])
 
 AM_CONDITIONAL([AMJSON], [ test x$with_json != xno])
 

--- a/doc/taskset.json
+++ b/doc/taskset.json
@@ -1,21 +1,21 @@
 {
-	"resources" : 4, 
+	"resources" : 4,
 	"tasks" : {
-		"thread0" : { 
-		       "exec" : 1000, 
-		       "period" : 10000, 
-		       "deadline" : 8000, 
-		       "cpus" : [0,1], 
-		       "policy" : "SCHED_FIFO", 
+		"thread0" : {
+		       "exec" : 1000,
+		       "period" : 10000,
+		       "deadline" : 8000,
+		       "cpus" : [0,1],
+		       "policy" : "SCHED_FIFO",
 		       "lock_order" : [0],
 		       "resources" : {
 			   "0" : { "duration" : 1000 }
 		       }
 		},
-		"thread1" : { 
-		       "exec" : 50000, 
-		       "period" : 100000, 
-		       "cpus" : [1], 
+		"thread1" : {
+		       "exec" : 50000,
+		       "period" : 100000,
+		       "cpus" : [1],
 		       "policy" : "SCHED_FIFO",
 		       "priority": 20,
         /*
@@ -49,7 +49,7 @@
 			   "1" : { "duration" : 100, "access": [3] },
 			   "2" : { "duration" : 200, "access": [1] },
 			   "3" : { "duration" : 500}
-		       }	
+		       }
 		}
 	},
 	"global" : {

--- a/doc/taskset.yml
+++ b/doc/taskset.yml
@@ -20,12 +20,12 @@ tasks:
                                 - duration : 1000
         t1:
                 - exec: 50000
-                  period: 100000      
+                  period: 100000
                   cpu: 1
                   policy: DEADLINE
                   lock: m0,m3,m2                        # optional. direct lock order
                   resources:
-                        - m0: 
+                        - m0:
                                 - duration: 1000        # usec, mandatory if present in $lock list.
                                   access : m2           # optional, list
                         - m1:
@@ -37,7 +37,7 @@ tasks:
                                   access: m1
 
                         - m3:
-                                - duration: 500                               
+                                - duration: 500
 
 global:
         # here values are set to their defaults, as an example.

--- a/libdl/dl_syscalls.h
+++ b/libdl/dl_syscalls.h
@@ -50,16 +50,16 @@
 
 struct sched_attr {
 	__u32 size;
-	
+
 	__u32 sched_policy;
 	__u64 sched_flags;
-	
+
 	/* SCHED_NORMAL, SCHED_BATCH */
 	__s32 sched_nice;
-	
+
 	/* SCHED_FIFO, SCHED_RR */
 	__u32 sched_priority;
-	
+
 	/* SCHED_DEADLINE */
 	__u64 sched_runtime;
 	__u64 sched_deadline;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,9 +1,9 @@
 ACLOCAL_AMFLAGS = -I m4
 AM_CPPFLAGS = -I$(srcdir)/../libdl/
 bin_PROGRAMS = rt-app
-rt_app_SOURCES= rt-app_types.h rt-app_args.h rt-app_utils.h rt-app_utils.c rt-app_args.c rt-app.h  rt-app.c 
+rt_app_SOURCES= rt-app_types.h rt-app_args.h rt-app_utils.h rt-app_utils.c rt-app_args.c rt-app.h  rt-app.c
 if AMJSON
 rt_app_SOURCES += rt-app_parse_config.h rt-app_parse_config.c
+AM_CPPFLAGS += $(LIBJSON_CFLAGS)
 endif
-rt_app_LDADD = $(QRESLIB) ../libdl/libdl.a $(LIBJSON)
-
+rt_app_LDADD = $(QRESLIB) ../libdl/libdl.a $(LIBJSON_LIBS)

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -338,10 +338,6 @@ void *thread_body(void *arg)
 		curr_timing->deadline = timespec_to_usec(&data->deadline);
 		curr_timing->duration = timespec_to_usec(&t_diff);
 		curr_timing->slack =  timespec_to_lusec(&t_slack);
-		if (curr_timing->slack < 0 && opts.die_on_dmiss) {
-			log_critical("[%d] DEADLINE MISS !!!", data->ind);
-			exit(EXIT_FAILURE);
-		}
 #ifdef AQUOSA
 		if (data->sched_policy == aquosa) {
 			curr_timing->budget = data->params.Q;
@@ -364,6 +360,10 @@ void *thread_body(void *arg)
 		data->deadline = timespec_add(&data->deadline, &data->period);
 		if (opts.ftrace)
 			log_ftrace(ft_data.marker_fd, "[%d] end loop %d", data->ind, i);
+		if (curr_timing->slack < 0 && opts.die_on_dmiss) {
+			log_critical("[%d] DEADLINE MISS !!!", data->ind);
+			exit(EXIT_FAILURE);
+		}
 		clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &t_next, NULL);
 		i++;
 	}

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -1,4 +1,4 @@
-/* 
+/*
 This file is part of rt-app - https://launchpad.net/rt-app
 Copyright (C) 2010  Giacomo Bagnoli <g.bagnoli@asidev.com>
 Copyright (C) 2014  Juri Lelli <juri.lelli@gmail.com>
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*/ 
+*/
 
 #include <fcntl.h>
 #include "rt-app.h"
@@ -48,7 +48,7 @@ static inline busywait(struct timespec *to)
 	}
 }
 
-void run(int ind, struct timespec *min, struct timespec *max, 
+void run(int ind, struct timespec *min, struct timespec *max,
 	 rtapp_tasks_resource_list_t *blockages, int nblockages)
 {
 	int i;
@@ -56,7 +56,7 @@ void run(int ind, struct timespec *min, struct timespec *max,
 	//struct timespec t_start, t_step, t_exec = msec_to_timespec(m);
 	struct timespec t_start, now, t_exec, t_totexec = *max;
 	rtapp_resource_access_list_t *lock, *last;
-	
+
 	/* get the start time */
 	clock_gettime(CLOCK_THREAD_CPUTIME_ID, &t_start);
 
@@ -144,7 +144,7 @@ void *thread_body(void *arg)
 	/* set thread affinity */
 	if (data->cpuset != NULL)
 	{
-		log_notice("[%d] setting cpu affinity to CPU(s) %s", data->ind, 
+		log_notice("[%d] setting cpu affinity to CPU(s) %s", data->ind,
 			 data->cpuset_str);
 		ret = pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t),
 						data->cpuset);
@@ -164,19 +164,19 @@ void *thread_body(void *arg)
 			fprintf(data->log_handler, "# Policy : %s\n",
 				(data->sched_policy == rr ? "SCHED_RR" : "SCHED_FIFO"));
 			param.sched_priority = data->sched_prio;
-			ret = pthread_setschedparam(pthread_self(), 
-						    data->sched_policy, 
+			ret = pthread_setschedparam(pthread_self(),
+						    data->sched_policy,
 						    &param);
 			if (ret != 0) {
-				errno = ret; 
-				perror("pthread_setschedparam"); 
+				errno = ret;
+				perror("pthread_setschedparam");
 				exit(EXIT_FAILURE);
 			}
 
 			log_notice("[%d] starting thread with period: %lu, exec: %lu,"
 			       "deadline: %lu, priority: %d",
 			       	data->ind,
-				timespec_to_usec(&data->period), 
+				timespec_to_usec(&data->period),
 				timespec_to_usec(&data->min_et),
 				timespec_to_usec(&data->deadline),
 				data->sched_prio
@@ -188,24 +188,24 @@ void *thread_body(void *arg)
 			log_notice("[%d] starting thread with period: %lu, exec: %lu,"
 			       "deadline: %lu",
 			       	data->ind,
-				timespec_to_usec(&data->period), 
+				timespec_to_usec(&data->period),
 				timespec_to_usec(&data->min_et),
 				timespec_to_usec(&data->deadline)
 			);
 			data->lock_pages = 0; /* forced off for SCHED_OTHER */
 			break;
-#ifdef AQUOSA			
+#ifdef AQUOSA
 		case aquosa:
 			fprintf(data->log_handler, "# Policy : AQUOSA\n");
-			data->params.Q_min = round((timespec_to_usec(&data->min_et) * (( 100.0 + data->sched_prio ) / 100)) / (data->fragment * 1.0)); 
+			data->params.Q_min = round((timespec_to_usec(&data->min_et) * (( 100.0 + data->sched_prio ) / 100)) / (data->fragment * 1.0));
 			data->params.Q = round((timespec_to_usec(&data->max_et) * (( 100.0 + data->sched_prio ) / 100)) / (data->fragment * 1.0));
 			data->params.P = round(timespec_to_usec(&data->period) / (data->fragment * 1.0));
 			data->params.flags = 0;
 			log_notice("[%d] Creating QRES Server with Q=%ld, P=%ld",
 				data->ind,data->params.Q, data->params.P);
-			
+
 			qos_chk_ok_exit(qres_init());
-			qos_chk_ok_exit(qres_create_server(&data->params, 
+			qos_chk_ok_exit(qres_create_server(&data->params,
 							   &data->sid));
 			log_notice("[%d] AQuoSA server ID: %d", data->ind, data->sid);
 			log_notice("[%d] attaching thread (deadline: %lu) to server %d",
@@ -229,16 +229,16 @@ void *thread_body(void *arg)
 				(timespec_to_nsec(&data->max_et) /100) * BUDGET_OVERP;
 			attr.sched_deadline = timespec_to_nsec(&data->period);
 			attr.sched_period = timespec_to_nsec(&data->period);
-				
+
 			break;
 #endif
-			
+
 		default:
 			log_error("Unknown scheduling policy %d",
 				data->sched_policy);
 			exit(EXIT_FAILURE);
 	}
-	
+
 	if (data->lock_pages == 1)
 	{
 		log_notice("[%d] Locking pages in memory", data->ind);
@@ -251,13 +251,13 @@ void *thread_body(void *arg)
 	}
 
 	if (data->wait_before_start > 0) {
-		log_notice("[%d] Waiting %ld usecs... ", data->ind, 
+		log_notice("[%d] Waiting %ld usecs... ", data->ind,
 			 data->wait_before_start);
 		clock_gettime(CLOCK_MONOTONIC, &t);
 		t_next = msec_to_timespec(data->wait_before_start);
 		t_next = timespec_add(&t, &t_next);
-		clock_nanosleep(CLOCK_MONOTONIC, 
-				TIMER_ABSTIME, 
+		clock_nanosleep(CLOCK_MONOTONIC,
+				TIMER_ABSTIME,
 				&t_next,
 				NULL);
 		log_notice("[%d] Starting...", data->ind);
@@ -267,9 +267,9 @@ void *thread_body(void *arg)
 	 */
 	timings = NULL;
 	if (data->duration > 0) {
-		my_duration_usec = (data->duration * 10e6) - 
+		my_duration_usec = (data->duration * 10e6) -
 				   (data->wait_before_start * 1000);
-		nperiods = (int) ceil( my_duration_usec / 
+		nperiods = (int) ceil( my_duration_usec /
 				      (double) timespec_to_usec(&data->period));
 		timings = malloc ( nperiods * sizeof(timing_point_t));
 	}
@@ -287,7 +287,7 @@ void *thread_body(void *arg)
 		log_notice("[%d] starting thread with period: %lu, exec: %lu,"
 		       "deadline: %lu, priority: %d",
 		       	data->ind,
-			attr.sched_period / 1000, 
+			attr.sched_period / 1000,
 			attr.sched_runtime / 1000,
 			attr.sched_deadline / 1000,
 			attr.sched_priority
@@ -319,11 +319,11 @@ void *thread_body(void *arg)
 		run(data->ind, &data->min_et, &data->max_et, data->blockages,
 		    data->nblockages);
 		clock_gettime(CLOCK_MONOTONIC, &t_end);
-		
+
 		t_diff = timespec_sub(&t_end, &t_start);
 		t_slack = timespec_sub(&data->deadline, &t_end);
 
-		t_start_usec = timespec_to_usec(&t_start); 
+		t_start_usec = timespec_to_usec(&t_start);
 		if (timings)
 			curr_timing = &timings[i];
 		else
@@ -332,7 +332,7 @@ void *thread_body(void *arg)
 		curr_timing->period = timespec_to_usec(&data->period);
 		curr_timing->min_et = timespec_to_usec(&data->min_et);
 		curr_timing->max_et = timespec_to_usec(&data->max_et);
-		curr_timing->rel_start_time = 
+		curr_timing->rel_start_time =
 			t_start_usec - timespec_to_usec(&data->main_app_start);
 		curr_timing->abs_start_time = t_start_usec;
 		curr_timing->end_time = timespec_to_usec(&t_end);
@@ -342,10 +342,10 @@ void *thread_body(void *arg)
 #ifdef AQUOSA
 		if (data->sched_policy == aquosa) {
 			curr_timing->budget = data->params.Q;
-			qres_get_exec_time(data->sid, 
-					   &abs_used_budget, 
+			qres_get_exec_time(data->sid,
+					   &abs_used_budget,
 					   NULL);
-			curr_timing->used_budget = 
+			curr_timing->used_budget =
 				abs_used_budget - prev_abs_used_budget;
 			prev_abs_used_budget = abs_used_budget;
 
@@ -376,19 +376,19 @@ void *thread_body(void *arg)
 
 exit_miss:
 	param.sched_priority = 0;
-	ret = pthread_setschedparam(pthread_self(), 
-				    SCHED_OTHER, 
+	ret = pthread_setschedparam(pthread_self(),
+				    SCHED_OTHER,
 				    &param);
 	if (ret != 0) {
-		errno = ret; 
-		perror("pthread_setschedparam"); 
+		errno = ret;
+		perror("pthread_setschedparam");
 		exit(EXIT_FAILURE);
 	}
 
 	if (timings)
 		for (j=0; j < i; j++)
 			log_timing(data->log_handler, &timings[j]);
-	
+
 	if (opts.ftrace)
 		log_ftrace(ft_data.marker_fd, "[%d] exiting", data->ind);
 	log_notice("[%d] Exiting.", data->ind);
@@ -418,7 +418,7 @@ int main(int argc, char* argv[])
 
 	nthreads = opts.nthreads;
 	threads = malloc(nthreads * sizeof(pthread_t));
-	
+
 	/* install a signal handler for proper shutdown */
 	signal(SIGQUIT, shutdown);
 	signal(SIGTERM, shutdown);
@@ -459,8 +459,8 @@ int main(int argc, char* argv[])
 		tdata = &opts.threads_data[i];
 		if (opts.spacing > 0 ) {
 			/* start the thread, then it will sleep accordingly
-			 * to its position. We don't sleep here anymore as 
-			 * this would mean that 
+			 * to its position. We don't sleep here anymore as
+			 * this would mean that
 			 * duration = spacing * nthreads + duration */
 			tdata->wait_before_start = opts.spacing * (i+1);
 		} else {
@@ -487,16 +487,16 @@ int main(int argc, char* argv[])
 		}
 
 		if (pthread_create(&threads[i],
-				  NULL, 
-				  thread_body, 
+				  NULL,
+				  thread_body,
 				  (void*) tdata))
 			goto exit_err;
 	}
 
-	/* print gnuplot files */ 
+	/* print gnuplot files */
 	if (opts.logdir && opts.gnuplot)
 	{
-		snprintf(tmp, PATH_LENGTH, "%s/%s-duration.plot", 
+		snprintf(tmp, PATH_LENGTH, "%s/%s-duration.plot",
 			 opts.logdir, opts.logbasename);
 		gnuplot_script = fopen(tmp, "w+");
 		snprintf(tmp, PATH_LENGTH, "%s-duration.eps",
@@ -516,11 +516,11 @@ int main(int argc, char* argv[])
 			snprintf(tmp, PATH_LENGTH, "%s/%s-duration.plot",
 				 opts.logdir, opts.logbasename);
 
-			fprintf(gnuplot_script, 
+			fprintf(gnuplot_script,
 				"\"%s-%s.log\" u ($5/1000):9 w l"
-				" title \"thread [%s] (%s)\"", 
-				opts.logbasename, opts.threads_data[i].name, 
-				opts.threads_data[i].name, 
+				" title \"thread [%s] (%s)\"",
+				opts.logbasename, opts.threads_data[i].name,
+				opts.threads_data[i].name,
 				opts.threads_data[i].sched_policy_descr);
 
 			if ( i == nthreads-1)
@@ -531,7 +531,7 @@ int main(int argc, char* argv[])
 		fprintf(gnuplot_script, "set terminal wxt\nreplot\n");
 		fclose(gnuplot_script);
 
-		snprintf(tmp, PATH_LENGTH, "%s/%s-slack.plot", 
+		snprintf(tmp, PATH_LENGTH, "%s/%s-slack.plot",
 		 	 opts.logdir, opts.logbasename);
 		gnuplot_script = fopen(tmp, "w+");
 		snprintf(tmp, PATH_LENGTH, "%s-slack.eps",
@@ -549,14 +549,14 @@ int main(int argc, char* argv[])
 
 		for (i=0; i < nthreads; i++)
 		{
-			fprintf(gnuplot_script, 
+			fprintf(gnuplot_script,
 				"\"%s-%s.log\" u ($5/1000):10 w l"
-				" title \"thread [%s] (%s)\"", 
+				" title \"thread [%s] (%s)\"",
 				opts.logbasename, opts.threads_data[i].name,
 				opts.threads_data[i].name,
 				opts.threads_data[i].sched_policy_descr);
 
-			if ( i == nthreads-1) 
+			if ( i == nthreads-1)
 				fprintf(gnuplot_script, ", 0 notitle\n");
 			else
 				fprintf(gnuplot_script, ", ");
@@ -565,7 +565,7 @@ int main(int argc, char* argv[])
 		fprintf(gnuplot_script, "set terminal wxt\nreplot\n");
 		fclose(gnuplot_script);
 	}
-	
+
 	if (opts.duration > 0)
 	{
 		sleep(opts.duration);
@@ -573,7 +573,7 @@ int main(int argc, char* argv[])
 			log_ftrace(ft_data.marker_fd, "main shutdown\n");
 		shutdown(SIGTERM);
 	}
-	
+
 	for (i = 0; i < nthreads; i++) 	{
 		pthread_join(threads[i], NULL);
 	}

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -1,6 +1,7 @@
 /* 
 This file is part of rt-app - https://launchpad.net/rt-app
 Copyright (C) 2010  Giacomo Bagnoli <g.bagnoli@asidev.com>
+Copyright (C) 2014  Juri Lelli <juri.lelli@gmail.com>
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -267,7 +267,7 @@ void *thread_body(void *arg)
 	 */
 	timings = NULL;
 	if (data->duration > 0) {
-		my_duration_usec = (data->duration * 10e6) -
+		my_duration_usec = (data->duration * 1e6) -
 				   (data->wait_before_start * 1000);
 		nperiods = (int) ceil( my_duration_usec /
 				      (double) timespec_to_usec(&data->period));

--- a/src/rt-app.h
+++ b/src/rt-app.h
@@ -1,4 +1,4 @@
-/* 
+/*
 This file is part of rt-app - https://launchpad.net/rt-app
 Copyright (C) 2010  Giacomo Bagnoli <g.bagnoli@asidev.com>
 Copyright (C) 2014  Juri Lelli <juri.lelli@gmail.com>
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*/ 
+*/
 
 #ifndef _RT_APP_H_
 #define _RT_APP_H_

--- a/src/rt-app.h
+++ b/src/rt-app.h
@@ -1,6 +1,7 @@
 /* 
 This file is part of rt-app - https://launchpad.net/rt-app
 Copyright (C) 2010  Giacomo Bagnoli <g.bagnoli@asidev.com>
+Copyright (C) 2014  Juri Lelli <juri.lelli@gmail.com>
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License

--- a/src/rt-app_args.c
+++ b/src/rt-app_args.c
@@ -1,4 +1,4 @@
-/* 
+/*
 This file is part of rt-app - https://launchpad.net/rt-app
 Copyright (C) 2010  Giacomo Bagnoli <g.bagnoli@asidev.com>
 Copyright (C) 2014  Juri Lelli <juri.lelli@gmail.com>
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*/ 
+*/
 
 #include "rt-app_args.h"
 
@@ -26,7 +26,7 @@ usage (const char* msg, int ex_code)
 #ifdef JSON
 	printf("usage:\n"
 	       "rt-app <taskset.json>\nOR\n");
-#endif	       
+#endif
 	printf("rt-app [options] -t <period>:<exec>[:policy"
 		"[:CPU affinity[:prio[:deadline]]]] -t ...\n\n");
 	printf("-h, --help\t\t:\tshow this help\n");
@@ -41,7 +41,7 @@ usage (const char* msg, int ex_code)
 	printf("-T, --ftrace\t\t:\tenable ftrace prints\n");
 	printf("-P, --pi_enabled\t:\tenable priority inheritance on resources\n");
 	printf("-M, --die_on_dmiss\t:\texit with an error if a task misses a deadline\n");
-	
+
 #ifdef AQUOSA
 	printf("-q, --qos\t:\tcreate AQuoSA reservation\n");
 	printf("-g, --frag\t:\tfragment for the reservation\n\n");
@@ -82,7 +82,7 @@ parse_thread_args(char *arg, int idx, thread_data_t *tdata, policy_t def_policy)
 	tdata->name = malloc(sizeof(char) * 5);
 	tdata->ind = idx;
 	/* default name for command line threads */
-	snprintf(tdata->name, 1, "t%d", tdata->ind); 
+	snprintf(tdata->name, 1, "t%d", tdata->ind);
 	tdata->sched_prio = DEFAULT_THREAD_PRIORITY;
 	tdata->sched_policy = def_policy;
 	tdata->cpuset = NULL;
@@ -94,7 +94,7 @@ parse_thread_args(char *arg, int idx, thread_data_t *tdata, policy_t def_policy)
 		case 0:
 			period = strtol(token, NULL, 10);
 			if (period <= 0 )
-				usage("Cannot set negative period.", 
+				usage("Cannot set negative period.",
 				      EXIT_INV_COMMANDLINE);
 			tdata->period = usec_to_timespec(period);
 			i++;
@@ -118,7 +118,7 @@ parse_thread_args(char *arg, int idx, thread_data_t *tdata, policy_t def_policy)
 #ifdef AQUOSA
 			if (strcmp(token,"q") == 0)
 				tdata->sched_policy = aquosa;
-			else 
+			else
 #endif
 #ifdef DLSCHED
 			if (strcmp(token,"d") == 0)
@@ -132,13 +132,13 @@ parse_thread_args(char *arg, int idx, thread_data_t *tdata, policy_t def_policy)
 			else if (strcmp(token,"o") == 0)
 				tdata->sched_policy = other;
 			else {
-				snprintf(tmp, 256, 
+				snprintf(tmp, 256,
 					"Invalid scheduling policy %s in %s",
 					token, arg);
 				usage(tmp, EXIT_INV_COMMANDLINE);
 			}
-			policy_to_string(tdata->sched_policy, 
-					 tdata->sched_policy_descr);	
+			policy_to_string(tdata->sched_policy,
+					 tdata->sched_policy_descr);
 
 			i++;
 			break;
@@ -180,7 +180,7 @@ parse_thread_args(char *arg, int idx, thread_data_t *tdata, policy_t def_policy)
 
 	if (dline == 0)
 		tdata->deadline = tdata->period;
-	
+
 	/* set cpu affinity mask */
 	if (tdata->cpuset_str)
 	{
@@ -192,9 +192,9 @@ parse_thread_args(char *arg, int idx, thread_data_t *tdata, policy_t def_policy)
 			strtok(NULL, ",");
 			i++;
 		}
-	} else 
+	} else
 		tdata->cpuset_str = strdup("-");
-	
+
 	free(str);
 }
 
@@ -244,10 +244,10 @@ parse_command_line_options(int argc, char **argv, rtapp_options_t *opts)
 	                   {0, 0, 0, 0}
 	               };
 #ifdef AQUOSA
-	while (( ch = getopt_long(argc,argv,"D:GKhfrb:s:l:qg:t:TM", 
+	while (( ch = getopt_long(argc,argv,"D:GKhfrb:s:l:qg:t:TM",
 				  long_options, &longopt_idx)) != -1)
 #else
-	while (( ch = getopt_long(argc,argv,"D:GKhfrb:s:l:t:TM", 
+	while (( ch = getopt_long(argc,argv,"D:GKhfrb:s:l:t:TM",
 				  long_options, &longopt_idx)) != -1)
 #endif
 	{
@@ -269,7 +269,7 @@ parse_command_line_options(int argc, char **argv, rtapp_options_t *opts)
 				opts->policy = rr;
 				break;
 			case 'b':
-				if (!opts->logdir)	
+				if (!opts->logdir)
 					opts->logdir = strdup(".");
 				opts->logbasename = strdup(optarg);
 				break;
@@ -280,7 +280,7 @@ parse_command_line_options(int argc, char **argv, rtapp_options_t *opts)
 					      EXIT_INV_COMMANDLINE);
 				break;
 			case 'l':
-				opts->logdir = strdup(optarg);	
+				opts->logdir = strdup(optarg);
 				lstat(opts->logdir, &dirstat);
 				if (! S_ISDIR(dirstat.st_mode))
 					usage("Cannot stat log directory",
@@ -290,7 +290,7 @@ parse_command_line_options(int argc, char **argv, rtapp_options_t *opts)
 				if (opts->nthreads > 0)
 				{
 					opts->threads_data = realloc(
-						opts->threads_data, 
+						opts->threads_data,
 						(opts->nthreads+1) * \
 							sizeof(thread_data_t));
 				}
@@ -320,7 +320,7 @@ parse_command_line_options(int argc, char **argv, rtapp_options_t *opts)
 			case 'M':
 				opts->die_on_dmiss = 1;
 				break;
-#ifdef AQUOSA				
+#ifdef AQUOSA
 			case 'q':
 				if (opts->policy != other)
 					usage("Cannot set multiple policies",
@@ -344,7 +344,7 @@ parse_command_line_options(int argc, char **argv, rtapp_options_t *opts)
 	if ( opts->nthreads < 1)
 		usage("You have to set parameters for at least one thread",
 		      EXIT_INV_COMMANDLINE);
-	
+
 }
 
 void
@@ -361,7 +361,7 @@ parse_command_line(int argc, char **argv, rtapp_options_t *opts)
 	else if (strcmp(argv[1], "-") == 0) {
 		parse_config_stdin(opts);
 		return;
-	} 
+	}
 #endif
 	parse_command_line_options(argc, argv, opts);
 	opts->resources = NULL;

--- a/src/rt-app_args.c
+++ b/src/rt-app_args.c
@@ -1,6 +1,7 @@
 /* 
 This file is part of rt-app - https://launchpad.net/rt-app
 Copyright (C) 2010  Giacomo Bagnoli <g.bagnoli@asidev.com>
+Copyright (C) 2014  Juri Lelli <juri.lelli@gmail.com>
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License

--- a/src/rt-app_args.h
+++ b/src/rt-app_args.h
@@ -1,4 +1,4 @@
-/* 
+/*
 This file is part of rt-app - https://launchpad.net/rt-app
 Copyright (C) 2010  Giacomo Bagnoli <g.bagnoli@asidev.com>
 Copyright (C) 2014  Juri Lelli <juri.lelli@gmail.com>
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*/ 
+*/
 
 #ifndef _RTAPP_ARGS_H_
 #define _RTAPP_ARGS_H_

--- a/src/rt-app_args.h
+++ b/src/rt-app_args.h
@@ -1,6 +1,7 @@
 /* 
 This file is part of rt-app - https://launchpad.net/rt-app
 Copyright (C) 2010  Giacomo Bagnoli <g.bagnoli@asidev.com>
+Copyright (C) 2014  Juri Lelli <juri.lelli@gmail.com>
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License

--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -1,4 +1,4 @@
-/* 
+/*
 This file is part of rt-app - https://launchpad.net/rt-app
 Copyright (C) 2010  Giacomo Bagnoli <g.bagnoli@asidev.com>
 Copyright (C) 2014  Juri Lelli <juri.lelli@gmail.com>
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*/ 
+*/
 
 #include "rt-app_parse_config.h"
 
@@ -37,7 +37,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 		 }							\
 		);							\
 		({ entry = entry->next; idx++; })			\
-	    )								
+	    )
 /* this macro set a default if key not present, or give an error and exit
  * if key is present but does not have a default */
 #define set_default_if_needed(key, value, have_def, def_value) do {	\
@@ -50,10 +50,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 			exit(EXIT_INV_CONFIG);				\
 		}							\
 	}								\
-} while(0)	
+} while(0)
 
-/* same as before, but for string, for which we need to strdup in the 
- * default value so it can be a literal */ 
+/* same as before, but for string, for which we need to strdup in the
+ * default value so it can be a literal */
 #define set_default_if_needed_str(key, value, have_def, def_value) do {	\
 	if (!value) {							\
 		if (have_def) {						\
@@ -87,17 +87,17 @@ assure_type_is(struct json_object *obj,
 	}
 }
 
-/* search a key (what) in object "where", and return a pointer to its 
+/* search a key (what) in object "where", and return a pointer to its
  * associated object. If nullable is false, exit if key is not found */
-static inline struct json_object* 
-get_in_object(struct json_object *where, 
+static inline struct json_object*
+get_in_object(struct json_object *where,
 	      const char *what,
 	      int nullable)
 {
-	struct json_object *to;	
+	struct json_object *to;
 	to = json_object_object_get(where, what);
 	if (!nullable && is_error(to)) {
-		log_critical(PFX "Error while parsing config:\n" PFL 
+		log_critical(PFX "Error while parsing config:\n" PFL
 			  "%s", json_tokener_errors[-(unsigned long)to]);
 		exit(EXIT_INV_CONFIG);
 	}
@@ -184,7 +184,7 @@ parse_resources(struct json_object *resources, rtapp_options_t *opts)
 	opts->nresources = res;
 }
 
-static void 
+static void
 serialize_acl(rtapp_resource_access_list_t **acl,
 	      int idx,
 	      struct json_object *task_resources,
@@ -192,7 +192,7 @@ serialize_acl(rtapp_resource_access_list_t **acl,
 {
 	int i, next_idx, found;
 	struct json_object *access, *res, *next_res;
-	rtapp_resource_access_list_t *tmp; 
+	rtapp_resource_access_list_t *tmp;
 	char s_idx[5];
 
 	/* as keys are string in the json, we need a string for searching
@@ -246,7 +246,7 @@ serialize_acl(rtapp_resource_access_list_t **acl,
 		/* recurse on the rest of resources */
 		serialize_acl(&(*acl), next_idx, task_resources, resources);
 	}
-	
+
 }
 
 static void
@@ -255,7 +255,7 @@ parse_thread_resources(const rtapp_options_t *opts, struct json_object *locks,
 {
 	int i,j, cur_res_idx, usage_usec;
 	struct json_object *res;
-	int res_dur;	
+	int res_dur;
 	char res_name[4];
 
 	rtapp_resource_access_list_t *tmp, *head, *last;
@@ -275,14 +275,14 @@ parse_thread_resources(const rtapp_options_t *opts, struct json_object *locks,
 
 		data->blockages[i].usage = usec_to_timespec(0);
 		data->blockages[i].acl = NULL;
-		serialize_acl(&data->blockages[i].acl, cur_res_idx, 
+		serialize_acl(&data->blockages[i].acl, cur_res_idx,
 				task_resources, opts->resources);
 
 		/* since the "current" resource is returned as the first
 		 * element in the list, we move it to the back  */
 		tmp = data->blockages[i].acl;
 		head = data->blockages[i].acl;
-		do {	
+		do {
 			last = tmp;
 			tmp = tmp->next;
 		} while (tmp != NULL);
@@ -312,18 +312,18 @@ parse_thread_resources(const rtapp_options_t *opts, struct json_object *locks,
 			usage_usec = 0;
 			data->blockages[i].usage = usec_to_timespec(0);
 		} else {
-			assure_type_is(res, task_resources, res_name, 
+			assure_type_is(res, task_resources, res_name,
 					json_type_object);
 			usage_usec = get_int_value_from(res, "duration", TRUE, 0);
 			data->blockages[i].usage = usec_to_timespec(usage_usec);
 		}
-		log_info(PIN "res %d, usage: %d acl: %s", cur_res_idx, 
+		log_info(PIN "res %d, usage: %d acl: %s", cur_res_idx,
 			  usage_usec, debug_msg);
 	}
 }
 
 static void
-parse_thread_data(char *name, struct json_object *obj, int idx, 
+parse_thread_data(char *name, struct json_object *obj, int idx,
 		  thread_data_t *data, const rtapp_options_t *opts)
 {
 	long exec, period, dline;
@@ -375,9 +375,9 @@ parse_thread_data(char *name, struct json_object *obj, int idx,
 	policy_to_string(data->sched_policy, data->sched_policy_descr);
 
 	/* priority */
-	data->sched_prio = get_int_value_from(obj, "priority", TRUE, 
+	data->sched_prio = get_int_value_from(obj, "priority", TRUE,
 					      DEFAULT_THREAD_PRIORITY);
-	
+
 	/* deadline */
 	dline = get_int_value_from(obj, "deadline", TRUE, period);
 	if (dline < exec) {
@@ -389,7 +389,7 @@ parse_thread_data(char *name, struct json_object *obj, int idx,
 		exit(EXIT_INV_CONFIG);
 	}
 	data->deadline = usec_to_timespec(dline);
-	
+
 	/* cpu set */
 	cpuset_obj = get_in_object(obj, "cpus", TRUE);
 	if (cpuset_obj) {
@@ -417,7 +417,7 @@ parse_thread_data(char *name, struct json_object *obj, int idx,
 		assure_type_is(locks, obj, "lock_order", json_type_array);
 		log_info(PIN "key: lock_order %s", json_object_to_json_string(locks));
 		if (resources) {
-			assure_type_is(resources, obj, "resources", 
+			assure_type_is(resources, obj, "resources",
 					json_type_object);
 			log_info(PIN "key: resources %s",
 				  json_object_to_json_string(resources));
@@ -453,7 +453,7 @@ parse_global(struct json_object *global, rtapp_options_t *opts)
 	opts->spacing = get_int_value_from(global, "spacing", TRUE, 0);
 	opts->duration = get_int_value_from(global, "duration", TRUE, -1);
 	opts->gnuplot = get_bool_value_from(global, "gnuplot", TRUE, 0);
-	policy = get_string_value_from(global, "default_policy", 
+	policy = get_string_value_from(global, "default_policy",
 				       TRUE, "SCHED_OTHER");
 	if (string_to_policy(policy, &opts->policy) != 0) {
 		log_critical(PFX "Invalid policy %s", policy);
@@ -461,14 +461,14 @@ parse_global(struct json_object *global, rtapp_options_t *opts)
 	}
 	opts->logdir = get_string_value_from(global, "logdir", TRUE, NULL);
 	opts->lock_pages = get_bool_value_from(global, "lock_pages", TRUE, 1);
-	opts->logbasename = get_string_value_from(global, "log_basename", 
+	opts->logbasename = get_string_value_from(global, "log_basename",
 						  TRUE, "rt-app");
 	opts->ftrace = get_bool_value_from(global, "ftrace", TRUE, 0);
 	opts->pi_enabled = get_bool_value_from(global, "pi_enabled", TRUE, 0);
 #ifdef AQUOSA
 	opts->fragment = get_int_value_from(global, "fragment", TRUE, 1);
 #endif
-	
+
 }
 
 static void
@@ -483,20 +483,20 @@ get_opts_from_json_object(struct json_object *root, rtapp_options_t *opts)
 	}
 	log_info(PFX "Successfully parsed input JSON");
 	log_info(PFX "root     : %s", json_object_to_json_string(root));
-	
+
 	global = get_in_object(root, "global", FALSE);
 	log_info(PFX "global   : %s", json_object_to_json_string(global));
-	
+
 	tasks = get_in_object(root, "tasks", FALSE);
 	log_info(PFX "tasks    : %s", json_object_to_json_string(tasks));
-	
+
 	resources = get_in_object(root, "resources", FALSE);
 	log_info(PFX "resources: %s", json_object_to_json_string(resources));
 
 	parse_global(global, opts);
 	parse_resources(resources, opts);
 	parse_tasks(tasks, opts);
-	
+
 }
 
 void

--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -1,6 +1,7 @@
 /* 
 This file is part of rt-app - https://launchpad.net/rt-app
 Copyright (C) 2010  Giacomo Bagnoli <g.bagnoli@asidev.com>
+Copyright (C) 2014  Juri Lelli <juri.lelli@gmail.com>
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License

--- a/src/rt-app_parse_config.h
+++ b/src/rt-app_parse_config.h
@@ -1,6 +1,7 @@
 /* 
 This file is part of rt-app - https://launchpad.net/rt-app
 Copyright (C) 2010  Giacomo Bagnoli <g.bagnoli@asidev.com>
+Copyright (C) 2014  Juri Lelli <juri.lelli@gmail.com>
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License

--- a/src/rt-app_parse_config.h
+++ b/src/rt-app_parse_config.h
@@ -1,4 +1,4 @@
-/* 
+/*
 This file is part of rt-app - https://launchpad.net/rt-app
 Copyright (C) 2010  Giacomo Bagnoli <g.bagnoli@asidev.com>
 Copyright (C) 2014  Juri Lelli <juri.lelli@gmail.com>
@@ -16,10 +16,10 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*/ 
+*/
 
 #ifndef _RTAPP_PARSE_CONFIG_H
-#define _RTAPP_PARSE_CONFIG_H 
+#define _RTAPP_PARSE_CONFIG_H
 /* for CPU_SET macro */
 #define _GNU_SOURCE
 
@@ -36,7 +36,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #ifdef DLSCHED
 #include "dl_syscalls.h"
 #endif
-#include <json/json.h>
+#include <json.h>
 
 #define DEFAULT_THREAD_PRIORITY 10
 #define PATH_LENGTH 256

--- a/src/rt-app_types.h
+++ b/src/rt-app_types.h
@@ -1,4 +1,4 @@
-/* 
+/*
 This file is part of rt-app - https://launchpad.net/rt-app
 Copyright (C) 2010  Giacomo Bagnoli <g.bagnoli@asidev.com>
 Copyright (C) 2014  Juri Lelli <juri.lelli@gmail.com>
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*/ 
+*/
 
 #ifndef _RTAPP_TYPES_H_
 #define _RTAPP_TYPES_H_
@@ -43,13 +43,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #define EXIT_INV_CONFIG 2
 #define EXIT_INV_COMMANDLINE 3
 
-typedef enum policy_t 
-{ 
-	other = SCHED_OTHER, 
-	rr = SCHED_RR, 
+typedef enum policy_t
+{
+	other = SCHED_OTHER,
+	rr = SCHED_RR,
 	fifo = SCHED_FIFO
 #ifdef AQUOSA
-	, aquosa = 1000 
+	, aquosa = 1000
 #endif
 #ifdef DLSCHED
 	, deadline = SCHED_DEADLINE
@@ -72,7 +72,7 @@ typedef struct _rtapp_resource_access_list_t {
 typedef struct _rtapp_tasks_resource_list_t {
 	struct timespec usage;
 	struct _rtapp_resource_access_list_t *acl;
-} rtapp_tasks_resource_list_t; 
+} rtapp_tasks_resource_list_t;
 
 typedef struct _thread_data_t {
 	int ind;
@@ -85,7 +85,7 @@ typedef struct _thread_data_t {
 	struct timespec min_et, max_et;
 	struct timespec period, deadline;
 	struct timespec main_app_start;
-    
+
 	FILE *log_handler;
 	policy_t sched_policy;
 	char sched_policy_descr[RTAPP_POLICY_DESCR_LENGTH];
@@ -113,18 +113,18 @@ typedef struct _ftrace_data_t {
 
 typedef struct _rtapp_options_t {
 	int lock_pages;
-	
+
 	thread_data_t *threads_data;
 	int nthreads;
-	
+
 	policy_t policy;
 	int duration;
 	unsigned long spacing;
-	
+
 	char *logdir;
 	char *logbasename;
 	int gnuplot;
-	
+
 	rtapp_resource_t *resources;
 	int nresources;
 	int pi_enabled;
@@ -154,4 +154,4 @@ typedef struct _timing_point_t {
 #endif
 } timing_point_t;
 
-#endif // _RTAPP_TYPES_H_ 
+#endif // _RTAPP_TYPES_H_

--- a/src/rt-app_types.h
+++ b/src/rt-app_types.h
@@ -1,6 +1,7 @@
 /* 
 This file is part of rt-app - https://launchpad.net/rt-app
 Copyright (C) 2010  Giacomo Bagnoli <g.bagnoli@asidev.com>
+Copyright (C) 2014  Juri Lelli <juri.lelli@gmail.com>
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License

--- a/src/rt-app_utils.c
+++ b/src/rt-app_utils.c
@@ -1,4 +1,4 @@
-/* 
+/*
 This file is part of rt-app - https://launchpad.net/rt-app
 Copyright (C) 2010  Giacomo Bagnoli <g.bagnoli@asidev.com>
 Copyright (C) 2014  Juri Lelli <juri.lelli@gmail.com>
@@ -16,23 +16,23 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*/ 
+*/
 
 #include "rt-app_utils.h"
 
-unsigned int 
+unsigned int
 timespec_to_msec(struct timespec *ts)
 {
 	return (ts->tv_sec * 1E9 + ts->tv_nsec) / 1000000;
 }
 
-long 
+long
 timespec_to_lusec(struct timespec *ts)
 {
 	return round((ts->tv_sec * 1E9 + ts->tv_nsec) / 1000.0);
 }
 
-unsigned long 
+unsigned long
 timespec_to_usec(struct timespec *ts)
 {
 	return round((ts->tv_sec * 1E9 + ts->tv_nsec) / 1000.0);
@@ -46,18 +46,18 @@ timespec_to_nsec(struct timespec *ts)
 }
 #endif
 
-struct timespec 
+struct timespec
 usec_to_timespec(unsigned long usec)
 {
 	struct timespec ts;
 
 	ts.tv_sec = usec / 1000000;
 	ts.tv_nsec = (usec % 1000000) * 1000;
-	
+
 	return ts;
 }
 
-struct timespec 
+struct timespec
 msec_to_timespec(unsigned int msec)
 {
 	struct timespec ts;
@@ -68,7 +68,7 @@ msec_to_timespec(unsigned int msec)
 	return ts;
 }
 
-struct timespec 
+struct timespec
 timespec_add(struct timespec *t1, struct timespec *t2)
 {
 	struct timespec ts;
@@ -84,24 +84,24 @@ timespec_add(struct timespec *t1, struct timespec *t2)
 	return ts;
 }
 
-struct timespec 
+struct timespec
 timespec_sub(struct timespec *t1, struct timespec *t2)
 {
 	struct timespec ts;
-	
+
 	if (t1->tv_nsec < t2->tv_nsec) {
 		ts.tv_sec = t1->tv_sec - t2->tv_sec -1;
-		ts.tv_nsec = t1->tv_nsec  + 1000000000 - t2->tv_nsec; 
+		ts.tv_nsec = t1->tv_nsec  + 1000000000 - t2->tv_nsec;
 	} else {
 		ts.tv_sec = t1->tv_sec - t2->tv_sec;
-		ts.tv_nsec = t1->tv_nsec - t2->tv_nsec; 
+		ts.tv_nsec = t1->tv_nsec - t2->tv_nsec;
 	}
 
 	return ts;
 
 }
 
-int 
+int
 timespec_lower(struct timespec *what, struct timespec *than)
 {
 	if (what->tv_sec > than->tv_sec)
@@ -119,7 +119,7 @@ timespec_lower(struct timespec *what, struct timespec *than)
 void
 log_timing(FILE *handler, timing_point_t *t)
 {
-	fprintf(handler, 
+	fprintf(handler,
 		"%d\t%lu\t%lu\t%lu\t%lu\t%lu\t%lu\t%lu\t%lu\t%ld",
 		t->ind,
 		t->period,
@@ -135,7 +135,7 @@ log_timing(FILE *handler, timing_point_t *t)
 #ifdef AQUOSA
 	fprintf(handler,
 		"\t" QRES_TIME_FMT "\t" QRES_TIME_FMT,
-		t->budget, 
+		t->budget,
 		t->used_budget
 	);
 #endif
@@ -186,7 +186,7 @@ policy_to_string(policy_t policy, char *policy_name)
 		case fifo:
 			strcpy(policy_name, "SCHED_FIFO");
 			break;
-#ifdef DLSCHED			
+#ifdef DLSCHED
 		case deadline:
 			strcpy(policy_name, "SCHED_DEADLINE");
 			break;
@@ -218,7 +218,7 @@ void ftrace_write(int mark_fd, const char *fmt, ...)
 		log_error("Cannot allocate ftrace buffer");
 		exit(EXIT_FAILURE);
 	}
-	
+
 	while(1) {
 		/* Try to print in the allocated space */
 		va_start(ap, fmt);

--- a/src/rt-app_utils.c
+++ b/src/rt-app_utils.c
@@ -1,6 +1,7 @@
 /* 
 This file is part of rt-app - https://launchpad.net/rt-app
 Copyright (C) 2010  Giacomo Bagnoli <g.bagnoli@asidev.com>
+Copyright (C) 2014  Juri Lelli <juri.lelli@gmail.com>
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License

--- a/src/rt-app_utils.h
+++ b/src/rt-app_utils.h
@@ -1,4 +1,4 @@
-/* 
+/*
 This file is part of rt-app - https://launchpad.net/rt-app
 Copyright (C) 2010  Giacomo Bagnoli <g.bagnoli@asidev.com>
 Copyright (C) 2014  Juri Lelli <juri.lelli@gmail.com>
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*/ 
+*/
 
 #ifndef _TIMESPEC_UTILS_H_
 #define _TIMESPEC_UTILS_H_
@@ -82,38 +82,38 @@ do {									\
     rtapp_log_to(stderr, LOG_LEVEL_CRITICAL, "<crit> ", msg, ##args);	\
 } while (0);
 
-unsigned int 
+unsigned int
 timespec_to_msec(struct timespec *ts);
 
-long 
+long
 timespec_to_lusec(struct timespec *ts);
 
-unsigned long 
+unsigned long
 timespec_to_usec(struct timespec *ts);
 
-struct timespec 
+struct timespec
 usec_to_timespec(unsigned long usec);
 
-struct timespec 
+struct timespec
 usec_to_timespec(unsigned long usec);
 
-struct timespec 
+struct timespec
 msec_to_timespec(unsigned int msec);
 
-struct timespec 
+struct timespec
 timespec_add(struct timespec *t1, struct timespec *t2);
 
-struct timespec 
+struct timespec
 timespec_sub(struct timespec *t1, struct timespec *t2);
 
-int 
+int
 timespec_lower(struct timespec *what, struct timespec *than);
 
 void
 log_timing(FILE *handler, timing_point_t *t);
 
 #ifdef DLSCHED
-pid_t 
+pid_t
 gettid(void);
 
 unsigned long long
@@ -129,6 +129,6 @@ policy_to_string(policy_t policy, char *policy_name);
 void
 ftrace_write(int mark_fd, const char *fmt, ...);
 
-#endif // _TIMESPEC_UTILS_H_ 
+#endif // _TIMESPEC_UTILS_H_
 
 /* vim: set ts=8 noexpandtab shiftwidth=8: */

--- a/src/rt-app_utils.h
+++ b/src/rt-app_utils.h
@@ -1,6 +1,7 @@
 /* 
 This file is part of rt-app - https://launchpad.net/rt-app
 Copyright (C) 2010  Giacomo Bagnoli <g.bagnoli@asidev.com>
+Copyright (C) 2014  Juri Lelli <juri.lelli@gmail.com>
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License


### PR DESCRIPTION
The calculation of the periods executed by a task related to the duration of the test is wrong. If you want to convert seconds to microseconds, then you have to multiply with 1e6 (=1.000.000) instead of 10e6 (=10.000.000). Only a small fix ;-)
Best regards,
Andreas
