### PR TITLE
Update github URL of the repository

### DIFF
--- a/README.in
+++ b/README.in
@@ -10,7 +10,7 @@ SCHED_RR as well as the AQuoSA framework and SCHED_DEADLINE.
 
 Code is currently maintained on GitHub:
 
-	https://github.com/gbagnoli/rt-app
+	https://github.com/scheduler-tools/rt-app/
 
 
 ==============


### PR DESCRIPTION
rt-app is no longer maintained in gbagnoli's github.  Update the URL.