### PR TITLE
Add Barrier Sync Primitive

### DIFF
--- a/doc/examples/tutorial/example7.json
+++ b/doc/examples/tutorial/example7.json
@@ -1,0 +1,64 @@
+{
+    /* Simple use case with two tasks driving each other in
+       turn. This demonstrates that the barrier event causes
+       tasks to be synchronized no matter which task reaches
+       the barrier first. The sequence which should be seen is:
+
+       time       task0                    task1
+        0000:      run                      run
+        1000:      sleep                    run
+        2000:      sleep                    wait FIRST
+        3000:      wait FIRST, then run     wait FIRST, then run
+        4000:      run                      sleep
+        5000:      wait SECOND              sleep
+        6000:      wait SECOND, then run    wait SECOND, then run
+
+       (These times will not be exactly reflected when you run
+        the example as we don't account for any scheduling effects
+        or run/sleep time variation in the explanation)
+
+       At 2000, task1 is waiting for the FIRST barrier however
+       task0 doesn't enter this barrier until the 2000-usec
+       sleep event completes at 3000. In this first barrier,
+       task1 waits for task0 to reach the synchronization point.
+
+       At 5000, task0 is waiting for the SECOND barrier, however
+       task1 does not enter this barrier until the 2000-usec
+       sleep event completes at 6000. In this second barrier,
+       task0 waits for task1 to reach the synchronization point.
+    */
+	"tasks" : {
+		"task0" : {
+			"loop" : -1,
+			"runtime1" : 1000,
+			"sleep1" : 2000,
+			"barrier1" : "FIRST",
+			"runtime2" : 2000,
+			"barrier2" : "SECOND",
+			"runtime3" : 1000,
+			"sleep3" : 2000,
+			"barrier3" : "THIRD",
+		},
+		"task1" : {
+			"loop" : -1,
+			"runtime1" : 2000,
+			"barrier1" : "FIRST",
+			"runtime2" : 1000,
+			"sleep2" : 2000,
+			"barrier2" : "SECOND",
+			"runtime3" : 2000,
+			"barrier3" : "THIRD",
+		},
+	},
+	"global" : {
+		"duration" : 5,
+		"calibration" : "CPU0",
+		"default_policy" : "SCHED_OTHER",
+		"pi_enabled" : false,
+		"lock_pages" : false,
+		"logdir" : "./",
+		"log_basename" : "rt-app1",
+		"ftrace" : true,
+		"gnuplot" : false,
+	}
+}

--- a/doc/tutorial.txt
+++ b/doc/tutorial.txt
@@ -422,6 +422,39 @@ following sequence:
 	"unlock" : "mutexA"
 }
 
+* barrier : String. Used as at least a pair where the name must match.
+Any number of matching uses will cause all threads hitting the barrier event
+to wait for a signal. The number of users is recorded, so that when the last user
+hits the barrier event, that thread will broadcast and continue to the next
+step. This is conceptually exactly the same as a pthread_barrier_wait operation
+however, using a pthread_barrier would impose some strict conditions on usage
+around thread cleanups - primarily that you cannot cancel an in-progress barrier
+operation which would mean that we have to restrict cleanup to only be possible
+at the end of a loop cycle (i.e. all phases are complete). This would be too
+restrictive for most uses so here we use an alternative.
+
+In this implementation, the barrier event manages its own mutex and uses a
+variable shared between users to track waiting tasks, protected by the mutex.
+
+You must use a unique name for each sync event since the number of users is
+taken from the number of references to the name in the input json. i.e. each
+name must represent a single sync point, and be shared amongst all threads
+which wish to syncronise at that point.
+
+The barrier event "barrier" : "SyncPointA"
+generates the following sequence:
+{
+    "lock" : "SyncPointA" (internal mutex),
+    If the shared variable is 0:
+      "signal" : "SyncPointA" (internal condvar),
+    Else:
+      decrement the shared variable,
+      "wait" : { "ref" : "SyncPointA" (internal condvar),
+                 "mutex" : "SyncPointA" (internal mutex) },
+      increment the shared variable,
+    "unlock" : "SyncPointA" (internal mutex)
+}
+
 * suspend : String. Block the calling thread until another thread wakes it up
 with resume. The String can be let empty as it will be filled by workgen with
 the right thread's name before starting the use case.

--- a/src/rt-app_types.h
+++ b/src/rt-app_types.h
@@ -70,7 +70,8 @@ typedef enum resource_t
 	rtapp_mem,
 	rtapp_iorun,
 	rtapp_runtime,
-	rtapp_yield
+	rtapp_yield,
+	rtapp_barrier
 } resource_t;
 
 struct _rtapp_mutex {
@@ -81,6 +82,20 @@ struct _rtapp_mutex {
 struct _rtapp_cond {
 	pthread_cond_t obj;
 	pthread_condattr_t attr;
+};
+
+struct _rtapp_barrier_like {
+	/* sync operation which works without ordering - everyone waits
+	 * until the last task arrives at the sync point. Conceptually
+	 * just like pthread_barrier except we don't have any cleanup
+	 * issues which barrier would impose */
+	/* mutex to guard read/write of the flag */
+	pthread_mutex_t m_obj;
+	pthread_mutexattr_t m_attr;
+	/* flag to indicate how many are waiting */
+	int waiting;
+	/* condvar to wait/signal on */
+	pthread_cond_t c_obj;
 };
 
 struct _rtapp_signal {
@@ -111,6 +126,7 @@ typedef struct _rtapp_resource_t {
 		struct _rtapp_timer timer;
 		struct _rtapp_iomem_buf buf;
 		struct _rtapp_iodev dev;
+		struct _rtapp_barrier_like barrier;
 	} res;
 	int index;
 	resource_t type;

--- a/src/rt-app_utils.c
+++ b/src/rt-app_utils.c
@@ -261,6 +261,9 @@ resource_to_string(resource_t resource, char *resource_name)
 		case rtapp_timer:
 			strcpy(resource_name, "timer");
 			break;
+		case rtapp_barrier:
+			strcpy(resource_name, "barrier");
+			break;
 		default:
 			return 1;
 	}


### PR DESCRIPTION
I wanted a way to provide a sync point for two threads where it didn't
matter which one got there first - the first thread to reach the sync
point would wait, and the last would just signal and continue.

Using a bare lock/signal/wait/unlock on both sides results in the second
thread being suspended briefly immediately after it signals which is
not desirable when trying to mimic existing thread activation patterns.

If we don't use bare signal/wait then it doesn't need to be restricted
to just 2 threads, you can sync an arbitrary number (>1) of threads at
a given point in a use case by including barrier events in them.

This effect could be achieved with a pthread_barrier, but there is no
officially sanctioned way to cancel a barrier sync event once it has
started and no way to tell if any threads are waiting without adding
such a mechanism externally, so we use the pattern here instead.

Each barrier point has a mutex, a shared counter and a condition
variable.

When parsing the usecase, the shared counter is incremented for
each reference.

At barrier sync, the event locks the event-specific mutex and checks
to see if it is the last task. If it is not the last task, then it
waits on the event-specific condition variable. If it is the last
task, then it sends a broadcast to all other users of the condition
variable. The shared counter is used to determine when the last
task reaches the sync point.

Signed-off-by: Chris Redpath <chris.redpath@arm.com>