### PR TITLE
rt-app: add support for "yield" event

### DIFF
--- a/doc/tutorial.txt
+++ b/doc/tutorial.txt
@@ -431,6 +431,8 @@ the right thread's name before starting the use case.
 taskA ...|run 5|suspend |----------------|run 5|suspend |----------------
 taskB ...-------------------|resume taskA|run 10    |-------------------- 
 
+* yield: String. Calls pthread_yield(), freeing the CPU for other tasks. This has a 
+special meaning for SCHED_DEADLINE tasks. String can be empty.
 
 **** Trace and Log ****
 

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -376,6 +376,12 @@ static int run_event(event_data_t *event, int dry_run,
 			ioload(event->count, &rdata->res.buf, ddata->res.dev.fd);
 		}
 		break;
+	case rtapp_yield:
+		{
+			log_debug("yield %d", event->count);
+			pthread_yield();
+		}
+		break;
 	}
 
 	return lock;

--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -546,6 +546,11 @@ parse_thread_event_data(char *name, struct json_object *obj,
 		log_info(PIN2 "type %d target %s [%d] mutex %s [%d]", data->type, rdata->name, rdata->index, ddata->name, ddata->index);
 		return;
 	}
+	if (!strncmp(name, "yield", strlen("yield"))) {
+		data->type = rtapp_yield;
+		log_info(PIN2 "type %d", data->type);
+		return;
+	}
 
 unknown_resource:
 	log_error(PIN2 "Resource %s not found in the resource section !!!", ref);
@@ -573,6 +578,7 @@ static char *events[] = {
 	"resume",
 	"mem",
 	"iorun",
+	"yield",
 	NULL
 };
 

--- a/src/rt-app_types.h
+++ b/src/rt-app_types.h
@@ -68,6 +68,7 @@ typedef enum resource_t
 	rtapp_mem,
 	rtapp_iorun,
 	rtapp_runtime,
+	rtapp_yield
 } resource_t;
 
 struct _rtapp_mutex {


### PR DESCRIPTION
"yield" event simply calls pthread_yield()
This has a special meaning for SCHED_DEADLINE tasks