### PR TITLE
doc: Fix ./configure command in tutorial.txt

### DIFF
--- a/doc/tutorial.txt
+++ b/doc/tutorial.txt
@@ -40,7 +40,7 @@ For rt-app:
 
 export ac_cv_lib_json_c_json_object_from_file=yes
 ./autogen.sh
-./configure --host=aarch64-linux-gnu LDFLAGS=" --static	-L<path to parent of json repo>/json-c/. libs/" CFLAGS="-I<path to parent of json repo>" --with-deadline
+./configure --host=aarch64-linux-gnu LDFLAGS=" --static	-L<path to parent of json repo>/json-c/." CFLAGS="-I<path to parent of json repo>" --with-deadline
 make
 
 e.g, with a directory structure like the following:


### PR DESCRIPTION
With the provided command I get this error from ./configure:

```
checking whether the C compiler works... no
configure: error: in `/home/brendan/sources/rt-app':
configure: error: C compiler cannot create executables
See `config.log' for more details
```

This seems to be because the "libs/" part is bogus.