### PR TITLE
Do not use json-c's is_error() any more

### DIFF
--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -895,7 +895,7 @@ get_opts_from_json_object(struct json_object *root, rtapp_options_t *opts)
 {
 	struct json_object *global, *tasks, *resources;
 
-	if (is_error(root)) {
+	if (root == NULL) {
 		log_error(PFX "Error while parsing input JSON");
 		exit(EXIT_INV_CONFIG);
 	}


### PR DESCRIPTION
In json-c-0.12 is_error() is defined in bits.h which is exported via
json.h. However, json-c's master branch contains commit d4e81f9ec827
which declares bits.h deprecated and removes the export via json.h.

Replace the use of is_error() with its trivial implementation to be
able to get rid of this single dependency towards the deprecated
bits.h.

This fixes an issue introduced by commit 17dd99c72a12 ("Clean-up header
file inferno") which removed #include <json-c/bits.h> from
src/rt-app_parse_config.c.

Cc: Olav Haugan <ohaugan@codeaurora.org>
Signed-off-by: Dietmar Eggemann <dietmar.eggemann@arm.com>
Acked-by: Vincent Guittot < vincent.guittot@linaro.org>