### PR TITLE
Enhancing debug prints

### DIFF
--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -406,13 +406,15 @@ int run(int ind,
 	int nbevents = pdata->nbevents;
 	int i, lock = 0;
 	unsigned long perf = 0;
+	char type_name[64];
 
 	for (i = 0; i < nbevents; i++)
 	{
 		if (!continue_running && !lock)
 			return perf;
 
-		log_debug("[%d] runs events %d type %d ", ind, i, events[i].type);
+		log_debug("[%d] runs events %d type %d %s ", ind, i, events[i].type,
+			  ( resource_to_string(events[i].type, type_name), type_name) );
 		if (opts.ftrace)
 				log_ftrace(ft_data.marker_fd,
 						"[%d] executing %d",

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -47,7 +47,7 @@ rtapp_options_t opts;
 static struct timespec t_zero;
 static pthread_barrier_t threads_barrier;
 
-static ftrace_data_t ft_data = {
+ftrace_data_t ft_data = {
 	.debugfs = "/sys/kernel/debug",
 	.marker_fd = -1,
 };

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -246,7 +246,7 @@ static void memload(unsigned long count, struct _rtapp_iomem_buf *iomem)
 
 static int run_event(event_data_t *event, int dry_run,
 		unsigned long *perf, rtapp_resource_t *resources,
-		struct timespec *t_first, log_data_t *ldata)
+		struct timespec *t_first, log_data_t *ldata, int task_idx)
 {
 	rtapp_resource_t *rdata = &(resources[event->res]);
 	rtapp_resource_t *ddata = &(resources[event->dep]);
@@ -254,14 +254,16 @@ static int run_event(event_data_t *event, int dry_run,
 
 	switch(event->type) {
 	case rtapp_lock:
-		log_debug("lock %s ", rdata->name);
+		log_debug("[%d] lock %s ", task_idx, rdata->name);
 		pthread_mutex_lock(&(rdata->res.mtx.obj));
 		lock = 1;
+		log_debug("[%d] lock - complete %s ", task_idx, rdata->name);
 		break;
 	case rtapp_unlock:
-		log_debug("unlock %s ", rdata->name);
+		log_debug("[%d] unlock %s ", task_idx, rdata->name);
 		pthread_mutex_unlock(&(rdata->res.mtx.obj));
 		lock = -1;
+		log_debug("[%d] unlock - complete %s ", task_idx, rdata->name);
 		break;
 	}
 
@@ -270,17 +272,22 @@ static int run_event(event_data_t *event, int dry_run,
 
 	switch(event->type) {
 	case rtapp_wait:
-		log_debug("wait %s ", rdata->name);
+		log_debug("[%d] wait %s ", task_idx, rdata->name);
 		pthread_cond_wait(&(rdata->res.cond.obj), &(ddata->res.mtx.obj));
+		log_debug("[%d] wait - complete %s ", task_idx, rdata->name);
 		break;
 	case rtapp_signal:
-		log_debug("signal %s ", rdata->name);
+		log_debug("[%d] signal %s ", task_idx, rdata->name);
 		pthread_cond_signal(&(rdata->res.cond.obj));
+		log_debug("[%d] signal - complete %s ", task_idx, rdata->name);
 		break;
 	case rtapp_sig_and_wait:
-		log_debug("signal and wait %s", rdata->name);
+		log_debug("[%d] sync %s", task_idx, rdata->name);
+		log_debug("[%d] sync - signal %s", task_idx, rdata->name);
 		pthread_cond_signal(&(rdata->res.cond.obj));
+		log_debug("[%d] sync - wait %s", task_idx, rdata->name);
 		pthread_cond_wait(&(rdata->res.cond.obj), &(ddata->res.mtx.obj));
+		log_debug("[%d] sync -complete %s", task_idx, rdata->name);
 		break;
 	case rtapp_broadcast:
 		pthread_cond_broadcast(&(rdata->res.cond.obj));
@@ -288,20 +295,28 @@ static int run_event(event_data_t *event, int dry_run,
 	case rtapp_sleep:
 		{
 		struct timespec sleep = usec_to_timespec(event->duration);
-		log_debug("sleep %d ", event->duration);
-		nanosleep(&sleep, NULL);
+		log_debug("[%d] sleep %d (%ld.%09ld) start", task_idx, event->duration, sleep.tv_sec, sleep.tv_nsec);
+		while(1) {
+			int result = nanosleep(&sleep, &sleep);
+			if (result == 0)
+				break;
+			log_debug("[%d] sleep %d broken with error %d (%ld.%09ld) left", task_idx, event->duration,
+					result, sleep.tv_sec, sleep.tv_nsec);
+			}
+		log_debug("[%d] sleep %d end. managed %ld.%09ld", task_idx, event->duration, sleep.tv_sec, sleep.tv_nsec);
 		}
 		break;
 	case rtapp_run:
 		{
 			struct timespec t_start, t_end;
-			log_debug("run %d ", event->duration);
+			log_debug("[%d] run %d start", task_idx, event->duration);
 			ldata->c_duration += event->duration;
 			clock_gettime(CLOCK_MONOTONIC, &t_start);
 			*perf += loadwait(event->duration);
 			clock_gettime(CLOCK_MONOTONIC, &t_end);
 			t_end = timespec_sub(&t_end, &t_start);
 			ldata->duration += timespec_to_usec(&t_end);
+			log_debug("[%d] run %d end. managed %lu usec", task_idx, event->duration, ldata->duration);
 		}
 		break;
 	case rtapp_runtime:
@@ -309,7 +324,7 @@ static int run_event(event_data_t *event, int dry_run,
 			struct timespec t_start, t_end;
 			int64_t diff_ns;
 
-			log_debug("runtime %d ", event->duration);
+			log_debug("[%d] runtime %d ", task_idx, event->duration);
 			ldata->c_duration += event->duration;
 			clock_gettime(CLOCK_MONOTONIC, &t_start);
 
@@ -323,12 +338,13 @@ static int run_event(event_data_t *event, int dry_run,
 
 			t_end = timespec_sub(&t_end, &t_start);
 			ldata->duration += timespec_to_usec(&t_end);
+			log_debug("[%d] runtime %d end. managed %lu usec", task_idx, event->duration, timespec_to_usec(&t_end));
 		}
 		break;
 	case rtapp_timer:
 		{
 			struct timespec t_period, t_now, t_wu, t_slack;
-			log_debug("timer %d ", event->duration);
+			log_debug("[%d] timer %d ", task_idx, event->duration);
 
 			t_period = usec_to_timespec(event->duration);
 			ldata->c_period += event->duration;
@@ -355,33 +371,42 @@ static int run_event(event_data_t *event, int dry_run,
 					clock_gettime(CLOCK_MONOTONIC, &rdata->res.timer.t_next);
 				ldata->wu_latency = 0UL;
 			}
+			log_debug("[%d] timer %d complete ", task_idx, event->duration);
 		}
 		break;
 	case rtapp_suspend:
 		{
-		log_debug("suspend %s ", rdata->name);
+		log_debug("[%d] suspend %s ", task_idx, rdata->name);
+		log_debug("[%d] suspend - lock %s ", task_idx, rdata->name);
 		pthread_mutex_lock(&(ddata->res.mtx.obj));
+		log_debug("[%d] suspend - lock complete. wait %s ", task_idx, rdata->name);
 		pthread_cond_wait(&(rdata->res.cond.obj), &(ddata->res.mtx.obj));
+		log_debug("[%d] suspend - wait complete. unlock %s ", task_idx, rdata->name);
 		pthread_mutex_unlock(&(ddata->res.mtx.obj));
+		log_debug("[%d] suspend - unlock complete %s ", task_idx, rdata->name);
 		break;
 		}
 	case rtapp_resume:
 		{
-		log_debug("resume %s ", rdata->name);
+		log_debug("[%d] resume %s ", task_idx, rdata->name);
+		log_debug("[%d] resume - lock %s ", task_idx, rdata->name);
 		pthread_mutex_lock(&(ddata->res.mtx.obj));
+		log_debug("[%d] resume - lock complete. broadcast %s ", task_idx, rdata->name);
 		pthread_cond_broadcast(&(rdata->res.cond.obj));
+		log_debug("[%d] resume - broadcast complete. unlock %s ", task_idx, rdata->name);
 		pthread_mutex_unlock(&(ddata->res.mtx.obj));
+		log_debug("[%d] resume - unlocked. done %s ", task_idx, rdata->name);
 		break;
 		}
 	case rtapp_mem:
 		{
-			log_debug("mem %d", event->count);
+			log_debug("[%d] mem %d", task_idx, event->count);
 			memload(event->count, &rdata->res.buf);
 		}
 		break;
 	case rtapp_iorun:
 		{
-			log_debug("iorun %d", event->count);
+			log_debug("[%d] iorun %d", task_idx, event->count);
 			ioload(event->count, &rdata->res.buf, ddata->res.dev.fd);
 		}
 		break;
@@ -420,7 +445,7 @@ int run(int ind,
 						"[%d] executing %d",
 						ind, i);
 		lock += run_event(&events[i], !continue_running, &perf,
-				  resources, t_first, ldata);
+				  resources, t_first, ldata, ind);
 	}
 
 	return perf;

--- a/src/rt-app_utils.c
+++ b/src/rt-app_utils.c
@@ -296,12 +296,12 @@ void ftrace_write(int mark_fd, const char *fmt, ...)
 	char *tmp, *ntmp;
 
 	if (mark_fd < 0) {
-		log_error("invalid mark_fd");
+		log_error_no_ftrace("invalid mark_fd");
 		exit(EXIT_FAILURE);
 	}
 
 	if ((tmp = malloc(size)) == NULL) {
-		log_error("Cannot allocate ftrace buffer");
+		log_error_no_ftrace("Cannot allocate ftrace buffer");
 		exit(EXIT_FAILURE);
 	}
 
@@ -316,11 +316,11 @@ void ftrace_write(int mark_fd, const char *fmt, ...)
 			ret = write(mark_fd, tmp, n);
 			free(tmp);
 			if (ret < 0) {
-				log_error("Cannot write mark_fd: %s\n",
+				log_error_no_ftrace("Cannot write mark_fd: %s\n",
 						strerror(errno));
 				exit(EXIT_FAILURE);
 			} else if (ret < n) {
-				log_debug("Cannot write all bytes at once into mark_fd\n");
+				log_debug_no_ftrace("Cannot write all bytes at once into mark_fd\n");
 			}
 			return;
 		}
@@ -333,7 +333,7 @@ void ftrace_write(int mark_fd, const char *fmt, ...)
 
 		if ((ntmp = realloc(tmp, size)) == NULL) {
 			free(tmp);
-			log_error("Cannot reallocate ftrace buffer");
+			log_error_no_ftrace("Cannot reallocate ftrace buffer");
 			exit(EXIT_FAILURE);
 		} else {
 			tmp = ntmp;

--- a/src/rt-app_utils.c
+++ b/src/rt-app_utils.c
@@ -261,7 +261,29 @@ resource_to_string(resource_t resource, char *resource_name)
 		case rtapp_timer:
 			strcpy(resource_name, "timer");
 			break;
+		case rtapp_lock:
+			strcpy(resource_name, "lock");
+			break;
+		case rtapp_unlock:
+			strcpy(resource_name, "unlock");
+			break;
+		case rtapp_suspend:
+			strcpy(resource_name, "suspend");
+			break;
+		case rtapp_resume:
+			strcpy(resource_name, "resume");
+			break;
+		case rtapp_mem:
+			strcpy(resource_name, "mem");
+			break;
+		case rtapp_iorun:
+			strcpy(resource_name, "iorun");
+			break;
+		case rtapp_runtime:
+			strcpy(resource_name, "runtime");
+			break;
 		default:
+			resource_name[0] = 0;
 			return 1;
 	}
 	return 0;


### PR DESCRIPTION
I've been trying to implement more complex use cases using rt-app primitives, and the existing debug infrastructure doesn't tell you that much about what's happening at playback time.

These patches let you see the names of shared resources and the thread indices so that you can figure out why your use case json doesn't run to completion.

I also added the ftrace output (when debug is enabled and ftrace channel is open) to make debugging using ftrace easier.