### PR TITLE
rtapp: Add broader support for specifying cpusets

### DIFF
--- a/doc/examples/tutorial/example8.json
+++ b/doc/examples/tutorial/example8.json
@@ -1,0 +1,40 @@
+{
+	/*
+	 * Simple use case which creates a thread with 3 phases each running for
+	 * 1.5ms. In phase 1 the thread will be affined to CPU 0, in phase 2 it
+	 * will be affined to CPU 1 and in the third phase it will be affined to
+	 * CPUs 2 (inherit from "cpus" at task level).
+	 */
+	"tasks" : {
+		"thread0" : {
+			"cpus" : [2],
+			"phases" : {
+				"phase1" : {
+					"cpus" : [0],
+					"loop" : 1,
+					"run" : 1500
+				},
+				"phase2" : {
+					"cpus" : [1],
+					"loop" : 1,
+					"run" : 1500
+				},
+				"phase3" : {
+					"loop" : 1,
+					"run" : 1500
+				}
+			}
+		}
+	},
+	"global" : {
+		"duration" : 2,
+		"calibration" : "CPU0",
+		"default_policy" : "SCHED_OTHER",
+		"pi_enabled" : false,
+		"lock_pages" : false,
+		"logdir" : "./",
+		"log_basename" : "rt-app1",
+		"ftrace" : true,
+		"gnuplot" : true
+	}
+}

--- a/doc/tutorial.txt
+++ b/doc/tutorial.txt
@@ -232,6 +232,43 @@ below are equals:
 	}
 }
 
+"cpus" can be specified at task level or phase level. As an example, below
+creates two threads. One thread will run with affinity of CPU 2 and 3. The
+second task will run first phase with affinity to CPU 0 and 1, second phase with
+affinity to CPU 2, and the third phase with affinity to CPU 4, 5, and 6 (it will
+inherit the affinity from the task level):
+
+"task" : {
+	"thread1" : {
+		"cpus" : [2,3],
+		"phases" : {
+			"phase1" : {
+				"run" : 10,
+				"sleep" : 10
+			}
+		}
+	}
+	"thread2" : {
+		"cpus" : [4,5,6],
+		"phases" : {
+			"phase1" : {
+				"cpus" : [0,1],
+				"run" : 10,
+				"sleep" : 10
+			}
+			"phase2" : {
+				"cpus" : [2],
+				"run" : 10,
+				"sleep" : 10
+			}
+			"phase3" : {
+				"run" : 10,
+				"sleep" : 10
+			}
+		}
+	}
+}
+
 * loop: Integer. Define the number of times the parent object must be run.
 The parent object can be a phase or a thread. For phase object, the loop
 defines the number of time the phase will be executed before starting the next

--- a/src/rt-app_types.h
+++ b/src/rt-app_types.h
@@ -141,10 +141,17 @@ typedef struct _event_data_t {
 	int count;
 } event_data_t;
 
+typedef struct _cpuset_data_t {
+	cpu_set_t *cpuset;
+	char *cpuset_str;
+	size_t cpusetsize;
+} cpuset_data_t;
+
 typedef struct _phase_data_t {
 	int loop;
 	event_data_t *events;
 	int nbevents;
+	cpuset_data_t cpu_data;
 } phase_data_t;
 
 typedef struct _thread_data_t {
@@ -153,8 +160,9 @@ typedef struct _thread_data_t {
 	int lock_pages;
 	int duration;
 	rtapp_resource_t **resources;
-	cpu_set_t *cpuset;
-	char *cpuset_str;
+	cpuset_data_t cpu_data; /* cpu set information */
+	cpuset_data_t *curr_cpu_data; /* Current cpu set being used */
+	cpuset_data_t def_cpu_data; /* Default cpu set for task */
 
 	unsigned long runtime, deadline, period;
 


### PR DESCRIPTION
Allow setting of cpusets at all levels of the spec.

Signed-off-by: Olav Haugan <ohaugan@codeaurora.org>
Tested-by: Dietmar Eggemann <dietmar.eggemann@arm.com>
Reviewed-by: Dietmar Eggemann <dietmar.eggemann@arm.com>
Tested-by: Viresh Kumar <viresh.kumar@linaro.org>
Acked-by: Juri Lelli <juri.lelli@arm.com>
Signed-off-by: Stephen Boyd <stephen.boyd@linaro.org>