### PR TITLE
rt-app: Fix broken 'loop' default value

### DIFF
--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -810,7 +810,7 @@ parse_thread_data(char *name, struct json_object *obj, int index,
 		data->phases = malloc(sizeof(phase_data_t) * data->nphases);
 		parse_thread_phase_data(obj,  &data->phases[0], opts, (long)data);
 		/* Get loop number */
-		data->loop = 1;
+		data->loop = -1;
 	}
 
 }


### PR DESCRIPTION
According to documentation the default value of 'loop' is -1, but the
threads without a loop field runs only once and stops.

Fix it.

Fixes: 3bda96e6e664 ("add phase feature")
Signed-off-by: Viresh Kumar <viresh.kumar@linaro.org>
Acked-by: Vincent Guittot <vincent.guittot@linaro.org>