### PR TITLE
configure: bump version to 1.0 and update copyright

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,7 @@
-AC_INIT([rt-app], [0.2_alpha2], [g.bagnoli@asidev.com])
-AC_COPYRIGHT([Copyright (C) 2009 Giacomo Bagnoli <g.bagnoli@asidev.com])
+AC_INIT([rt-app], [1.0], [juri.lelli@arm.com, vincent.guittot@linaro.org])
+AC_COPYRIGHT([Copyright (C) 2009 Giacomo Bagnoli <g.bagnoli@asidev.com>
+Copyright (C) 2016 Juri Lelli      <juri.lelli@arm.com>
+Copyright (C) 2016 Vincent Guittot <vincent.guittot@linaro.org>])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign dist-bzip2])
 m4_pattern_allow([AM_PROG_AR])


### PR DESCRIPTION
It is time we bump version to 1.0 (as major development happened and lot
of new features got merged).

Also update Copyright information to reflect current maintainers.

Signed-off-by: Juri Lelli <juri.lelli@arm.com>