### PR TITLE
Fix loop property handling

### DIFF
--- a/doc/tutorial.txt
+++ b/doc/tutorial.txt
@@ -269,11 +269,12 @@ inherit the affinity from the task level):
 	}
 }
 
-* loop: Integer. Define the number of times the parent object must be run.
-The parent object can be a phase or a thread. For phase object, the loop
-defines the number of time the phase will be executed before starting the next
-phase. For thread object, the loop defines the number of times that the
-complete "phases" object will be executed. The default value is -1.
+* loop: Integer. Define the number of times the parent object must be run.  The
+  parent object can be a phase or a thread. For phase object, the loop defines
+the number of time the phase will be executed before starting the next phase.
+For thread object, the loop defines the number of times that the complete
+"phases" object will be executed. The default value is -1 for thread object and
+1 for phases.
 
 *** events ***
 

--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -799,6 +799,7 @@ parse_thread_data(char *name, struct json_object *obj, int index,
 		data->phases = malloc(sizeof(phase_data_t) * data->nphases);
 		foreach(phases_obj, entry, key, val, idx) {
 			log_info(PIN "Parsing phase %s", key);
+			assure_type_is(val, phases_obj, key, json_type_object);
 			parse_thread_phase_data(val, &data->phases[idx], opts, (long)data);
 		}
 

--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -810,8 +810,21 @@ parse_thread_data(char *name, struct json_object *obj, int index,
 		data->nphases = 1;
 		data->phases = malloc(sizeof(phase_data_t) * data->nphases);
 		parse_thread_phase_data(obj,  &data->phases[0], opts, (long)data);
-		/* Get loop number */
-		data->loop = -1;
+
+		/*
+		 * Get loop number:
+		 *
+		 * If loop is specified, we already parsed it in
+		 * parse_thread_phase_data() above, so we just need to remember
+		 * that we don't want to loop forever.
+		 *
+		 * If not specified we want to loop forever.
+		 *
+		 */
+		if (get_in_object(obj, "loop", TRUE))
+			data->loop = 1;
+		else
+			data->loop = -1;
 	}
 
 }


### PR DESCRIPTION
loop property handling appears to be broken (i.e., loop at thread level is ignored and always defaults to -1 when there isn't a phases object).
Fix it by also sanitising code a bit.