### PR TITLE
Fixes/loadwait perf

### DIFF
--- a/doc/tutorial.txt
+++ b/doc/tutorial.txt
@@ -570,7 +570,7 @@ finished to execute its events.
 
 You can log some metrics for each phase that is executed by a thread. These
 metrics are:
-- perf: number of loop that has been executed by run events
+- perf: fixed amount of work perfomed during a phase (c_duration/calibration)
 - run: time spent by the thread to execute the run events
 - period: duration to execute the complte phase
 - start/end : absolute start and end time of a phase. Same time base is used in

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -183,9 +183,15 @@ int calibrate_cpu_cycles(int clock)
 
 static inline unsigned long loadwait(unsigned long exec)
 {
-	unsigned long load_count;
-	unsigned long secs;
+	unsigned long load_count, secs, perf;
 	int i;
+
+	/*
+	 * Performace is the fixed amount of work that is performed by this run
+	 * phase. We need to compute it here because both load_count and exec
+	 * might be modified below.
+	 */
+	perf = exec / p_load;
 
 	/*
 	 * If exec is still too big, let's run it in bursts
@@ -205,7 +211,7 @@ static inline unsigned long loadwait(unsigned long exec)
 	load_count = (exec * 1000)/p_load;
 	waste_cpu_cycles(load_count);
 
-	return load_count;
+	return perf;
 }
 
 static void ioload(unsigned long count, struct _rtapp_iomem_buf *iomem, int io_fd)


### PR DESCRIPTION
perf metric is broken when exec is multiple of 1s: it returns 0.
Fix the problem and propose to decrease perf metric granularity to reduce overflow probability.