### PR TITLE
rt-app/json-c: missing json-c returns error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ AC_HEADER_STDC
 AC_CHECK_LIB([pthread], [pthread_create])
 AC_CHECK_LIB([m], [round])
 AC_CHECK_LIB([rt], [clock_gettime])
-AC_CHECK_LIB([json-c], [json_object_from_file])
+AC_CHECK_LIB([json-c], [json_object_from_file], [], [AC_MSG_ERROR([json-c libraries required])])
 AC_CHECK_FUNCS(sched_setattr, [], [])
 
 AC_ARG_WITH([deadline],


### PR DESCRIPTION
return an error if lib json-c is  not present so you don't try to compile

Signed-off-by: Vincent Guittot <vincent.guittot@linaro.org>