### PR TITLE
Return simple help and version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([rt-app], [1.0], [juri.lelli@arm.com, vincent.guittot@linaro.org])
+AC_INIT([rt-app], [m4_esyscmd_s([git describe --tags HEAD])], [juri.lelli@arm.com, vincent.guittot@linaro.org])
 AC_COPYRIGHT([Copyright (C) 2009 Giacomo Bagnoli <g.bagnoli@asidev.com>
 Copyright (C) 2016 Juri Lelli      <juri.lelli@arm.com>
 Copyright (C) 2016 Vincent Guittot <vincent.guittot@linaro.org>])
@@ -33,6 +33,8 @@ if test -z "${LOGLVL}";then
 else
 	AC_DEFINE_UNQUOTED([LOG_LEVEL], [${LOGLVL}])
 fi
+
+AC_DEFINE([BUILD_DATE], ["m4_esyscmd_s([date +"%Y-%m-%d %H:%M:%S %Z"])"], [Build date.])
 
 AC_CONFIG_HEADERS([src/config.h])
 AC_CONFIG_FILES([Makefile src/Makefile libdl/Makefile README COPYING])

--- a/src/rt-app_args.c
+++ b/src/rt-app_args.c
@@ -23,36 +23,79 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <getopt.h>
 
 #include "rt-app_parse_config.h"
 
+char help_usage[] = \
+"Usage: rt-app <taskset.json>\n"
+"Try 'rt-app --help' for more information.\n";
+
+char help_full[] = \
+"Usage:\n"
+"      rt-app <taskset.json>\n"
+"      cat taskset.json | rt-app -\n\n"
+"taskset.json is a json file describing the workload that will be generated"
+"by rt-app.\n\n"
+"In the first example, the json file is opened and parsed by rt-app.\n"
+"In the second example, rt-app reads the workload description in json format\n"
+"through the standard input.\n\n"
+"Miscellaneous:\n"
+"  -v, --version             display version information and exit\n"
+"  -h, --help                display this help text and exit\n";
+
 void
-usage (const char* msg, int ex_code)
+usage(const char* msg, int ex_code)
 {
-	printf("usage:\n"
-	       "rt-app <taskset.json>\n");
+	printf("%s", help_usage);
 
 	if (msg != NULL)
 		printf("\n%s\n", msg);
 	exit(ex_code);
 }
 
+struct option long_args[] = {
+	{"help",	no_argument,	0,	'h'},
+	{"version",	no_argument,	0,	'v'},
+	{0,		0,		0,	0}
+};
+
 void
 parse_command_line(int argc, char **argv, rtapp_options_t *opts)
 {
 	struct stat config_file_stat;
+	int c;
 
-	if (argc < 2)
-		usage(NULL, EXIT_SUCCESS);
+	while (1) {
+		c = getopt_long(argc, argv, "hv", long_args, 0);
+		if (c == -1)
+			break;
 
-	if (stat(argv[1], &config_file_stat) == 0) {
-		parse_config(argv[1], opts);
-		return;
-	} else if (strcmp(argv[1], "-") == 0) {
-		parse_config_stdin(opts);
-		return;
+		switch (c) {
+		case 'h':
+			printf("%s", help_full);
+			exit(0);
+			break;
+		case 'v':
+			printf("%s %s (%s)\n",
+			       PACKAGE,
+			       VERSION,
+			       BUILD_DATE);
+			exit(0);
+			break;
+		default:
+			usage(NULL, EXIT_INV_COMMANDLINE);
+			break;
+		}
 	}
 
-	usage(NULL, EXIT_SUCCESS);
-}
+	if (optind >= argc)
+		usage(NULL, EXIT_INV_COMMANDLINE);
 
+	if (stat(argv[optind], &config_file_stat) == 0)
+		parse_config(argv[optind], opts);
+	else if (strcmp(argv[optind], "-") == 0)
+		parse_config_stdin(opts);
+	else
+		usage(NULL, EXIT_FAILURE);
+}


### PR DESCRIPTION
Since it often happens to distribute already (cross)compiled rt-app
executables, it is useful to add a way to check the release version of
the software.
This patch adds the software version and build information to the
executable, that can be accessed with the arguments -v or --version
with the following syntax:

[PACKAGE] [git describe --tags HEAD] ([BUILD DATE])

$ rt-app -v|--version
rt-app v1.0-29-g6f10c0c (2017-12-06 16:39:38 GMT)

Moreover, a simple help is returned when using the arguments -h or
--help.