### PR TITLE
Bugfix on handling wrong dl parameters

### DIFF
--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -785,9 +785,20 @@ void *thread_body(void *arg)
 	 */
 
 	/* Set scheduling policy and print pretty info on stdout */
-	log_notice("[%d] Starting with %s policy with priority %d",
-			data->ind, policy_to_string(data->sched_data->policy),
-			data->sched_data->prio);
+	if (data->sched_data->policy == deadline) {
+		log_notice("[%d] Starting with %s policy with runtime %ld, deadline %ld, period %ld",
+			   data->ind,
+			   policy_to_string(data->sched_data->policy),
+			   data->sched_data->runtime,
+			   data->sched_data->deadline,
+			   data->sched_data->period);
+	} else {
+		log_notice("[%d] Starting with %s policy with priority %d",
+			   data->ind,
+			   policy_to_string(data->sched_data->policy),
+			   data->sched_data->prio);
+	}
+
 	set_thread_priority(data, data->sched_data);
 
 	/*


### PR DESCRIPTION
In the following trivial workload example, where "exec" is used instead of
"runtime", rt-app crashes with a segmentation fault without notifying
the user of what was wrong.

{
  "global": {
    "duration": 10,
    "default_policy": "SCHED_DEADLINE"
  },
  "tasks": {
    "Task_0": {
      "deadline": 3000000,
      "period": 3000000,
      "exec": 2900000
    }
  }
}

This patch:
 - solves the problem by imposing the correctness of the dl parameters
   or notifying the error and exiting.
 - Refactors the code that parses dl parameters.
 - Added duplicates of logging printers for dl tasks, printing runtime,
   deadline and period instead of priority.