### PR TITLE
rt-app: fix error handling of threads without events

### DIFF
--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -768,10 +768,14 @@ parse_thread_phase_data(struct json_object *obj,
 		if (obj_is_event(key))
 				data->nbevents++;
 	}
-	log_info(PIN "Found %d events", data->nbevents);
 
-	if (data->nbevents == 0)
-		return;
+	if (data->nbevents == 0) {
+		log_critical(PIN "No events found. Task must have events or it's useless");
+		exit(EXIT_INV_CONFIG);
+
+	}
+
+	log_info(PIN "Found %d events", data->nbevents);
 
 	data->events = malloc(data->nbevents * sizeof(event_data_t));
 


### PR DESCRIPTION
A thread without events to run is useless and must be considered as an
error

Reported-by: Alessio Balsini <alessio.balsini@arm.com>
Signed-off-by: Vincent Guittot <vincent.guittot@linaro.org>