### PR TITLE
Remove unsued sched_prio from struct _phase_data_t

### DIFF
--- a/src/rt-app_types.h
+++ b/src/rt-app_types.h
@@ -160,7 +160,6 @@ typedef struct _phase_data_t {
 	int loop;
 	event_data_t *events;
 	int nbevents;
-	int sched_prio;
 	cpuset_data_t cpu_data;
 	sched_data_t *sched_data;
 } phase_data_t;


### PR DESCRIPTION
Commit ("rt-app: add per phase set priority event") moved the priority
related data into struct _sched_data_t. The struct _phase_data_t also
contains a sched_data_t pointer so there is no need to have an
additional int sched_prio data element.

Signed-off-by: Dietmar Eggemann <dietmar.eggemann@arm.com>