### PR TITLE
Add taskgroup support for SCHED_OTHER tasks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,23 @@ AC_CHECK_LIB([rt], [clock_gettime])
 AC_CHECK_LIB([json-c], [json_object_from_file], [], [AC_MSG_ERROR([json-c libraries required])])
 AC_CHECK_FUNCS(sched_setattr, [], [])
 
+AC_ARG_WITH([cgroup],
+	[AS_HELP_STRING([--with-cgroup],
+	[Add support for cpu cgroups])],
+	[],
+	[with_cgroup=no])
+
+LIBCGROUP=
+AS_IF([test "x$with_cgroup" != xno],
+      AC_CHECK_LIB([cgroup], [cgroup_init],
+		   [AC_SUBST([LIBCGROUP], ["-lcgroup"])
+		   AC_DEFINE([HAVE_LIBCGROUP], [1], [Define if you have CGroup support])
+		   ],
+		   [AC_MSG_FAILURE([libcgroup test failed (use --without-cgroup to disable or install cgroup)])],
+		   [-lcgroup]
+		  )
+      )
+
 AC_ARG_WITH([deadline],
 	[AS_HELP_STRING([--with-deadline], 
 		[Add support for SCHED_DEADLINE])],

--- a/doc/tutorial.txt
+++ b/doc/tutorial.txt
@@ -36,11 +36,29 @@ export ac_cv_func_realloc_0_nonnull=yes
 ./configure --host=aarch64-linux-gnu --disable-shared --enable-static
 make
 
+For libcgroup: (tested with v0.41)
+
+./git clone https://github.com/matsumoto-r/libcgroup.git
+
+export ac_cv_func_malloc_0_nonnull=yes
+export ac_cv_func_realloc_0_nonnull=yes
+autoreconf -v --install
+./configure --host=aarch64-linux-gnu --disable-shared --enable-static --disable-pam --disable-daemon --disable-tools
+make
+
 For rt-app:
 
 export ac_cv_lib_json_c_json_object_from_file=yes
 ./autogen.sh
+
+w/o taskgroup (cgroup) support:
+
 ./configure --host=aarch64-linux-gnu LDFLAGS=" --static -L<path to parent of json repo>/json-c/." CFLAGS="-I<path to parent of json repo>" --with-deadline
+
+w/ taskgroup (cgroup) support:
+
+./configure --host=aarch64-linux-gnu LDFLAGS="--static -L<path to parent of json repo>/json-c/. -L<path to parent of libcgroup repo>/src/.libs" CFLAGS="-I<path to parent of libcgroup repo>/include --I<path to parent of json repo>" --with-deadline --with-cgroup
+
 make
 
 e.g, with a directory structure like the following:
@@ -297,6 +315,43 @@ inherit the affinity from the task level):
 				"sleep" : 10
 			}
 			"phase3" : {
+				"run" : 10,
+				"sleep" : 10
+			}
+		}
+	}
+}
+
+*** taskgroup ***
+
+* taskgroup: String. Can be specified at task level or phase level. The
+example below sets up a task 'thread1' with three phases. The task will
+run in taskgroup '/tg1/tg11' in the  phase1, in '/tg1' in phase2 and in
+'/' (root taskgroup) in phase3. Phase 2 does not specify a cgroup so the
+phase will inherit from the task. Currently only SCHED_OTHER tasks are
+supported.
+An empty taskgroup value ("") is allowed and is interpreted as if there
+is no taskgroup name/value pair given, so the thread or phase runs in
+the root taskgroup.
+An rt-app binary w/o taskgroup support ignores any taskgroup related
+name/value pairs.
+
+"task" : {
+	"thread1" : {
+		"policy": "SCHED_OTHER",
+		"taskgroup": "/tg1",
+		"phases" : {
+			"phase1" : {
+				"taskgroup": "/tg1/tg11",
+				"run" : 10,
+				"sleep" : 10
+			},
+			"phase2" : {
+				"run" : 10,
+				"sleep" : 10
+			},
+			"phase3" : {
+				"taskgroup": "/",
 				"run" : 10,
 				"sleep" : 10
 			}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,7 +3,7 @@ AM_CPPFLAGS = -I$(srcdir)/../libdl/
 bin_PROGRAMS = rt-app
 rt_app_SOURCES= rt-app_types.h rt-app_args.h rt-app_utils.h rt-app_utils.c rt-app_args.c rt-app.h  rt-app.c 
 rt_app_SOURCES += rt-app_parse_config.h rt-app_parse_config.c
-rt_app_LDADD = $(QRESLIB)
+rt_app_LDADD = $(QRESLIB) $(LIBCGROUP)
 if SET_DLSCHED
 rt_app_LDADD += ../libdl/libdl.a
 endif

--- a/src/rt-app.h
+++ b/src/rt-app.h
@@ -23,6 +23,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #define _RT_APP_H_
 
 void *thread_body(void *arg);
+#ifdef HAVE_LIBCGROUP
+void split_taskgroup_data(rtapp_options_t *opts, char *name);
+taskgroup_t* find_taskgroup(rtapp_options_t *opts, char *name);
+#endif
 
 #endif /* _RT_APP_H_ */
 


### PR DESCRIPTION
The implementation is based on libcgroup. It can be optionally
configured by specifying --with-cgroup.

Building instruction and an example are given in doc/tutorial.txt.

For now an rt-app binary w/ taskgroup support only allows SCHED_NORMAL
policy.

It can run on a kernel w/o cpu controller support in case there are
no taskgroups other than a root ("/") or an empty taskgroup ("")
configured.

An rt-app binary w/o taskgroup support ignores any taskgroup related
name/value pairs.

Tested on x86_64 and arm64.

Known issue: The build shows some warnings that some of the functions
in libcgroup.a (e.g. cgroup_change_cgroup_flags()) are calling
functions (e.g. getgrgid()) which require at run-time the same
version of shared libraries from the glibc version used for linking.

Signed-off-by: Dietmar Eggemann <dietmar.eggemann@arm.com>