### PR TITLE
fix sched_other policy setting

### DIFF
--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -648,13 +648,15 @@ static void set_thread_priority(thread_data_t *data, sched_data_t *sched_data)
 				exit(EXIT_FAILURE);
 			}
 
-			ret = setpriority(PRIO_PROCESS, 0,
-					sched_data->prio);
+			param.sched_priority = sched_data->prio;
+			ret = pthread_setschedparam(pthread_self(),
+					sched_data->policy,
+					&param);
 			if (ret != 0) {
-				log_critical("[%d] setpriority"
+				log_critical("[%d] pthread_setschedparam"
 				     "returned %d", data->ind, ret);
 				errno = ret;
-				perror("setpriority");
+				perror("pthread_setschedparam");
 				exit(EXIT_FAILURE);
 			}
 


### PR DESCRIPTION
Use pthread_setschedparam instead of setpriority for setting task into
CFS class. setpriority only changes the CFS priority but not the scheduling
class.
When a task has been set to fifo class, it can't move back to other class

Signed-off-by: Vincent Guittot <vincent.guittot@linaro.org>