### PR TITLE
Fork support

### DIFF
--- a/doc/examples/tutorial/example9.json
+++ b/doc/examples/tutorial/example9.json
@@ -1,0 +1,56 @@
+{
+	/*
+	 * A simple example on using fork event.
+	 *
+	 * thread3 will fork thread1 and thread2 in each of its phases.
+	 * Note that thread2 will NOT be instantiated at start time and
+	 * will only run when thread3 forks it. Unlike thread1 which will
+	 * run at the start - since default value of instance property is
+	 * 1 - and will run again when thread3 forks ie: twice in total.
+	 */
+	"tasks" : {
+		"thread1" : {
+			"phases" : {
+				"phase1" : {
+					"run" : 10000,
+					"sleep" : 10000
+				}
+			}
+		},
+		"thread2" : {
+			"instance": 0,
+			"phases" : {
+				"phase1" : {
+					"run" : 20000,
+					"sleep" : 20000
+				}
+			}
+		},
+		"thread3" : {
+			"phases" : {
+				"phase1" : {
+					"fork": "thread1",
+					"run" : 10000,
+					"sleep" : 10000
+				},
+				"phase2" : {
+					"fork": "thread2",
+					"run" : 20000,
+					"sleep" : 20000
+				}
+			},
+			"loop": 1
+		}
+	},
+	"global" : {
+		"duration" : 2,
+		"calibration" : "CPU0",
+		"default_policy" : "SCHED_OTHER",
+		"pi_enabled" : false,
+		"lock_pages" : false,
+		"logdir" : "./",
+		"log_basename" : "rt-app1",
+		"ftrace" : false,
+		"gnuplot" : false
+	}
+}

--- a/doc/tutorial.txt
+++ b/doc/tutorial.txt
@@ -136,7 +136,8 @@ several threads can be created with the same object (see instance parameter
 below).
 
 * instance : Integer. Define the number of threads that will be created with
-the properties of this thread object. Default value is 1.
+the properties of this thread object. Default value is 1. A value of 0 will
+create the structures of the task but will not create a pthread.
 
 * delay: Integer. Initial delay before a thread starts execution. The unit
 is usec.

--- a/doc/tutorial.txt
+++ b/doc/tutorial.txt
@@ -489,6 +489,10 @@ taskB ...-------------------|resume taskA|run 10    |--------------------
 * yield: String. Calls pthread_yield(), freeing the CPU for other tasks. This has a
 special meaning for SCHED_DEADLINE tasks. String can be empty.
 
+* fork: String. Instead of creating all tasks at start time, you can fork one
+at any point of time using this event. The name of the forked task must match
+one of the defined tasks.
+
 **** Trace and Log ****
 
 Some traces and log hooks have been added to ease the debug and monitor various

--- a/src/rt-app_types.h
+++ b/src/rt-app_types.h
@@ -42,6 +42,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #define EXIT_INV_CONFIG 2
 #define EXIT_INV_COMMANDLINE 3
 
+struct _thread_data_t;
+
 typedef enum policy_t
 {
 	other = SCHED_OTHER,
@@ -72,7 +74,8 @@ typedef enum resource_t
 	rtapp_iorun,
 	rtapp_runtime,
 	rtapp_yield,
-	rtapp_barrier
+	rtapp_barrier,
+	rtapp_fork
 } resource_t;
 
 struct _rtapp_mutex {
@@ -118,6 +121,12 @@ struct _rtapp_iodev {
 	int fd;
 };
 
+struct _rtapp_fork {
+	struct _thread_data_t *tdata;
+	char *ref;
+	int nforks;
+};
+
 /* Shared resources */
 typedef struct _rtapp_resource_t {
 	union {
@@ -128,6 +137,7 @@ typedef struct _rtapp_resource_t {
 		struct _rtapp_iomem_buf buf;
 		struct _rtapp_iodev dev;
 		struct _rtapp_barrier_like barrier;
+		struct _rtapp_fork fork;
 	} res;
 	int index;
 	resource_t type;
@@ -187,6 +197,8 @@ typedef struct _thread_data_t {
 	FILE *log_handler;
 
 	unsigned long delay;
+
+	int forked;
 } thread_data_t;
 
 typedef struct _ftrace_data_t {

--- a/src/rt-app_types.h
+++ b/src/rt-app_types.h
@@ -221,6 +221,7 @@ typedef struct _rtapp_options_t {
 
 	thread_data_t *threads_data;
 	int nthreads;
+	int nzthreads;
 
 	policy_t policy;
 	int duration;

--- a/src/rt-app_types.h
+++ b/src/rt-app_types.h
@@ -199,6 +199,7 @@ typedef struct _thread_data_t {
 	unsigned long delay;
 
 	int forked;
+	int num_instances;
 } thread_data_t;
 
 typedef struct _ftrace_data_t {
@@ -221,7 +222,7 @@ typedef struct _rtapp_options_t {
 
 	thread_data_t *threads_data;
 	int nthreads;
-	int nzthreads;
+	int num_tasks;
 
 	policy_t policy;
 	int duration;


### PR DESCRIPTION
To be able to test scheduler behaviour when forking a new thread, we need to be able to fork half way through the experiment.

This pull request adds a new 'fork' event to fork a new thread at a selected point of time rather just at rt-app startup. The new forked threads doesn't accept phases for simplicity. And there's a hard limit of 1024 forks to keep the resource allocation static at rt-app start rather than dynamically allocate at runtime which could 'interfere' with the experiment.

The pull request also fixes a typo in tutorial.txt which states that the default value of lock_pages is false but it is actually true.

I still need to update tutorial.txt to include the new fork event, but first want to make sure the approach is acceptable.

Thanks.