### PR TITLE
actually use the loop value for phase-less threads, changes in documentation that hopefully clarify how looping works.

### DIFF
--- a/doc/tutorial.txt
+++ b/doc/tutorial.txt
@@ -222,12 +222,12 @@ below are equals:
 Several properties can be set at thread and/or phase levels. All these
 properties are optional and default value will be used if nothing is defined.
 
-* loop: Integer. Define the number of times the parent object must be run.  The
-  parent object can be a phase or a thread. For phase object, the loop defines
-the number of time the phase will be executed before starting the next phase.
-For thread object, the loop defines the number of times that the complete
-"phases" object will be executed. The default value is -1 for thread object and
-1 for phases.
+* loop : Integer. Define the number of times the object (thread or phase) must
+be run. For a phase, the loop defines the number of time the phase will be
+executed before starting the next phase. For a thread, the loop defines the
+number of times that the sequence of phases (defined by the "phases" object)
+will be executed. The default value is -1 for threads (loop indefinitely) and 1
+for phases (run once).
 
 *** scheduling policy
 

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -811,13 +811,13 @@ void *thread_body(void *arg)
 	 * phase        - index of current phase in data->phases array
 	 * phase_loop   - current iteration of current phase
 	 *                (corresponds to "loop" at phase level)
-	 * thread_loop  - current iteration of thread/phases
+	 * thread_loop  - current iteration of thread
 	 *                (corresponds to "loop" at task level
 	 * log_idx      - index of current row in the log buffer
 	 */
 	phase = phase_loop = thread_loop = log_idx = 0;
 
-	/* The following is executed for each phase. */
+	/* The following is executed for each thread_loop. */
 	while (continue_running && thread_loop != data->loop) {
 		struct timespec t_diff, t_rel_start;
 

--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -873,7 +873,7 @@ parse_thread_data(char *name, struct json_object *obj, int index,
 		 *
 		 */
 		if (get_in_object(obj, "loop", TRUE))
-			data->loop = 1;
+			data->loop = get_int_value_from(obj, "loop", TRUE, 1);
 		else
 			data->loop = -1;
 	}


### PR DESCRIPTION
if a thread without a phase is declared, the 'loop' setting was ignored and '1' was used, instead. (i am assuming that this should apply to the thread, is that correct?)