### PR TITLE
[FIX] compile issue (not declare TRUE and FALSE)

### DIFF
--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 #include <stdio.h>
 #include <string.h>
+#include <stdbool.h>
 #include <fcntl.h>
 #include <json-c/json.h>
 
@@ -37,6 +38,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #define PIN3 PIN2"    "
 #define JSON_FILE_BUF_SIZE 4096
 #define DEFAULT_MEM_BUF_SIZE (4 * 1024 * 1024)
+#define TRUE true
+#define FALSE false
 
 /* redefine foreach as in <json/json_object.h> but to be ANSI
  * compatible */

--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -38,8 +38,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #define PIN3 PIN2"    "
 #define JSON_FILE_BUF_SIZE 4096
 #define DEFAULT_MEM_BUF_SIZE (4 * 1024 * 1024)
+
+#ifndef TRUE
 #define TRUE true
 #define FALSE false
+#endif
 
 /* redefine foreach as in <json/json_object.h> but to be ANSI
  * compatible */


### PR DESCRIPTION
-The intent of your change.
	1. Fix compile issue (not declare TRUE and FALSE) 
	
- Short log / Statement of what needed to be changed.
        1. Add stdbool.h
	2. declared TRUE, FALSE (Jason header remove it) again.
	3. If previous json-c already declared, skip it.

- distro version
	ubuntu 16.04.05  64bit
	
-Signed-off-by: pino-kim sungwon.pino@gmail.com