### PR TITLE
parse_config: Define TRUE and FALSE if not already defined by json-c.

### DIFF
--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 #include <stdio.h>
 #include <string.h>
+#include <stdbool.h>
 #include <fcntl.h>
 #include <json-c/json.h>
 
@@ -37,6 +38,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #define PIN3 PIN2"    "
 #define JSON_FILE_BUF_SIZE 4096
 #define DEFAULT_MEM_BUF_SIZE (4 * 1024 * 1024)
+
+#ifndef TRUE
+#define TRUE true
+#define FALSE false
+#endif
 
 /* redefine foreach as in <json/json_object.h> but to be ANSI
  * compatible */


### PR DESCRIPTION
Some newer versions of json-c library stopped defining TRUE and FALSE
and this causes a compile issue.

Fix it my defining those if not yet defined by json-c (to be back and
forward compatible with the library).