### PR TITLE
Add taskgroups support for SCHED_OTHER tasks

### DIFF
--- a/doc/examples/tutorial/example10.json
+++ b/doc/examples/tutorial/example10.json
@@ -1,0 +1,26 @@
+{
+	/*
+	 * Use case which creates a thread that runs 2ms then sleep 8ms
+	 * in taskgroup /tg1. The use case runs for 2secs or until it
+	 * is stopped with Ctrl+C.
+	 */
+	"tasks" : {
+		"thread0" : {
+			"loop" : -1,
+			"run" :   20000,
+			"sleep" : 80000,
+			"taskgroup" : "/tg1"
+		}
+	},
+	"global" : {
+		"duration" : 2,
+		"calibration" : "CPU0",
+		"default_policy" : "SCHED_OTHER",
+		"pi_enabled" : false,
+		"lock_pages" : false,
+		"logdir" : "./",
+		"log_basename" : "rt-app1",
+		"ftrace" : true,
+		"gnuplot" : true
+	}
+}

--- a/doc/examples/tutorial/example11.json
+++ b/doc/examples/tutorial/example11.json
@@ -1,0 +1,42 @@
+{
+	/*
+	 * Use case which creates a thread with 3 phases. In each phase the thread
+	 * runs for 2ms and then sleeps for 8ms. In phase0 the thread runs in
+	 * taskgroup /tg1/tg11. Phase1 does not specify a taskgroup so the thread
+	 * will continue to run in taskgroup /tg1/tg11. In phase2 the thread will
+	 * run in taskgroup / (the root taskgroup). The use case runs for 2secs or
+	 * until it is stopped with Ctrl+C.
+	 */
+	"tasks" : {
+		"thread0" : {
+			"loop" : -1,
+			"phases" : {
+				"phase0" : {
+					"run" : 20000,
+					"sleep" : 80000,
+					"taskgroup" : "/tg1/tg11"
+				},
+				"phase1" : {
+					"run" : 20000,
+					"sleep" : 80000
+				},
+				"phase2" : {
+					"run" : 20000,
+					"sleep" : 80000,
+					"taskgroup" : "/"
+				}
+			}
+		}
+	},
+	"global" : {
+		"duration" : 2,
+		"calibration" : "CPU0",
+		"default_policy" : "SCHED_OTHER",
+		"pi_enabled" : false,
+		"lock_pages" : false,
+		"logdir" : "./",
+		"log_basename" : "rt-app1",
+		"ftrace" : true,
+		"gnuplot" : true
+	}
+}

--- a/doc/tutorial.txt
+++ b/doc/tutorial.txt
@@ -258,6 +258,20 @@ inherit the affinity from the task level):
 	}
 }
 
+*** taskgroups
+
+* taskgroup: String. Can be specified at task level or phase level. Currently
+only SCHED_OTHER tasks are supported to contain taskgroup data. Tasks with a
+policy other than SCHED_OTHER and without taskgroup data can coexist in the
+setup. An empty taskgroup ("") is allowed and is interpreted as if there is
+no taskgroup data given. Pre-existing parts of a taskgroup are preserved.
+They are not removed during rt-app teardown.
+The default build supports up to 32 different taskgroups. In case a
+configuration exceeds this limit the error message '[rt-app] <error> [tg] #
+taskgroups exceeds max # taskgroups [32]' is issued before rt-app exits. The
+number of supported taskgroups can be increased by changing 'const static
+unsigned int max_nbr_tgs = 32' at compile time.
+
 *** events ***
 
 events are simple action that will be performed by the thread or on the

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,7 +2,7 @@ ACLOCAL_AMFLAGS = -I m4
 AM_CPPFLAGS = -I$(srcdir)/../libdl/
 bin_PROGRAMS = rt-app
 rt_app_SOURCES= rt-app_types.h rt-app_args.h rt-app_utils.h rt-app_utils.c rt-app_args.c rt-app.h  rt-app.c 
-rt_app_SOURCES += rt-app_parse_config.h rt-app_parse_config.c
+rt_app_SOURCES += rt-app_parse_config.h rt-app_parse_config.c rt-app_taskgroups.h rt-app_taskgroups.c
 rt_app_LDADD = $(QRESLIB)
 if SET_DLSCHED
 rt_app_LDADD += ../libdl/libdl.a

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -1168,6 +1168,9 @@ void *thread_body(void *arg)
 		exit(EXIT_FAILURE);
 	}
 
+	/* Force thread into root taskgroup. */
+	reset_thread_taskgroup();
+
 	if (timings) {
 		int j;
 

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -1068,6 +1068,7 @@ void *thread_body(void *arg)
 			data->ind, policy_to_string(data->sched_data->policy),
 			data->sched_data->prio);
 	set_thread_priority(data, data->sched_data);
+	set_thread_taskgroup(data, data->taskgroup_data);
 
 	/*
 	 * phase        - index of current phase in data->phases array
@@ -1085,6 +1086,7 @@ void *thread_body(void *arg)
 
 		set_thread_affinity(data, &pdata->cpu_data);
 		set_thread_priority(data, pdata->sched_data);
+		set_thread_taskgroup(data, pdata->taskgroup_data);
 
 		if (opts.ftrace)
 			log_ftrace(ft_data.marker_fd,

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -37,6 +37,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "config.h"
 #include "rt-app_utils.h"
 #include "rt-app_args.h"
+#include "rt-app_taskgroups.h"
 
 /*
  * To prevent infinite loops in fork bombs, we will limit the number of
@@ -712,6 +713,8 @@ static void __shutdown(bool force_terminate)
 		close(ft_data.marker_fd);
 	}
 
+	remove_cgroups();
+
 	/*
 	 * If we unlock the joining_mutex here we could risk a late SIGINT
 	 * causing us to re-enter this loop. Since we are calling exit() to
@@ -1273,6 +1276,9 @@ int main(int argc, char* argv[])
 		log_notice("pLoad = %dns", p_load);
 	}
 
+	initialize_cgroups();
+	add_cgroups();
+
 	/* Take the beginning time for everything */
 	clock_gettime(CLOCK_MONOTONIC, &t_start);
 
@@ -1438,5 +1444,6 @@ int main(int argc, char* argv[])
 	__shutdown(false);
 
 exit_err:
+	remove_cgroups();
 	exit(EXIT_FAILURE);
 }

--- a/src/rt-app_taskgroups.c
+++ b/src/rt-app_taskgroups.c
@@ -93,6 +93,14 @@ void set_thread_taskgroup(thread_data_t *data, taskgroup_data_t *tg)
 	data->curr_taskgroup_data = tg;
 }
 
+void reset_thread_taskgroup(void)
+{
+	if (!ctrl.nr_tgs)
+		return;
+
+	cgroup_attach_task("/");
+}
+
 static int cgroup_check_cpu_controller(void)
 {
 	int dummy[2], enabled, ret = 0;

--- a/src/rt-app_taskgroups.c
+++ b/src/rt-app_taskgroups.c
@@ -1,0 +1,74 @@
+#include <stdlib.h>
+#include <string.h>
+#include <mntent.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <stdio.h>
+#include <errno.h>
+
+#include "config.h"
+#include "rt-app_utils.h"
+#include "rt-app_taskgroups.h"
+
+#define PIN "[tg] "
+
+typedef struct _taskgroup_ctrl_t
+{
+	char *mount_point;
+	taskgroup_data_t *tg_array;
+	unsigned int nr_tgs;
+} taskgroup_ctrl_t;
+
+static taskgroup_ctrl_t ctrl;
+
+const static unsigned int max_nbr_tgs = 32;
+
+static void initialize_taskgroups(void)
+{
+	size_t size = max_nbr_tgs * sizeof(taskgroup_data_t);
+
+	ctrl.tg_array = malloc(size);
+	if (!ctrl.tg_array) {
+		perror("malloc");
+		exit(EXIT_FAILURE);
+	}
+}
+
+taskgroup_data_t *alloc_taskgroup(size_t size)
+{
+	taskgroup_data_t *tg;
+
+	if (!ctrl.nr_tgs)
+		initialize_taskgroups();
+
+	if (ctrl.nr_tgs >= max_nbr_tgs) {
+		log_error(PIN "# taskgroups exceeds max # taskgroups [%u]",
+			   max_nbr_tgs);
+		return NULL;
+	}
+
+	tg = &ctrl.tg_array[ctrl.nr_tgs++];
+
+	tg->name = malloc(size);
+	if (!tg->name) {
+		perror("malloc");
+		return NULL;
+	}
+	tg->offset = 0;
+
+	log_debug(PIN "# taskgroups allocated [%u]", ctrl.nr_tgs);
+
+	return tg;
+}
+
+taskgroup_data_t *find_taskgroup(char *name)
+{
+	taskgroup_data_t *tg = ctrl.tg_array;
+	unsigned int i;
+
+	for (i = 0; i < ctrl.nr_tgs; i++, tg++)
+		if (!strcmp(tg->name, name))
+			return tg;
+
+	return NULL;
+}

--- a/src/rt-app_taskgroups.c
+++ b/src/rt-app_taskgroups.c
@@ -72,3 +72,268 @@ taskgroup_data_t *find_taskgroup(char *name)
 
 	return NULL;
 }
+
+static int cgroup_check_cpu_controller(void)
+{
+	int dummy[2], enabled, ret = 0;
+	FILE *cgroups;
+	char buf[512];
+
+	cgroups = fopen("/proc/cgroups", "re");
+
+	if (!cgroups) {
+		perror("fopen");
+		goto err;
+	}
+
+	/* Ignore the first line as it contains the header. */
+	if (!fgets(buf, sizeof(buf), cgroups)) {
+		perror("fgets");
+		goto err;
+	}
+
+	while (!feof(cgroups)) {
+		/*
+		 * Only interested in 'subsys_name' and 'enabled' column
+		 * of /proc/cgroups, not in 'hierarchy' or 'num_cgroups'.
+		 */
+		if (fscanf(cgroups, "%s %d %d %d", buf, &dummy[0], &dummy[1],
+			   &enabled) < 4) {
+			perror("fscanf");
+			goto err;
+		}
+
+		if (!strcmp(buf, "cpu") && enabled == 1)
+			goto done;
+	}
+err:
+	ret = -1;
+done:
+	if (cgroups)
+		fclose(cgroups);
+
+	return ret;
+}
+
+static int cgroup_get_cpu_controller_mount_point(void)
+{
+	struct mntent *ent;
+	FILE *mounts;
+	int ret = -1;
+
+	mounts = setmntent("/proc/mounts", "re");
+
+	if (!mounts) {
+		perror("setmntent");
+		return ret;
+	}
+
+	while (ent = getmntent(mounts)) {
+		if (strcmp(ent->mnt_type, "cgroup"))
+			continue;
+
+		if (!hasmntopt(ent, "cpu"))
+			continue;
+
+		ctrl.mount_point = malloc(strlen(ent->mnt_dir) + 1);
+		if (!ctrl.mount_point) {
+			perror("malloc");
+			break;
+		}
+
+		strcpy(ctrl.mount_point, ent->mnt_dir);
+
+		log_debug(PIN "cgroup cpu controller mountpoint [%s] found", ent->mnt_dir);
+		ret = 0;
+		break;
+	}
+
+	endmntent(mounts);
+	return ret;
+}
+
+void initialize_cgroups(void)
+{
+	if (!ctrl.nr_tgs)
+		return;
+
+	if (cgroup_check_cpu_controller()) {
+		log_error(PIN "no cgroup cpu controller found");
+		exit(EXIT_FAILURE);
+	}
+
+	if (cgroup_get_cpu_controller_mount_point()) {
+		log_error(PIN "no cgroup cpu controller mointpoint found");
+		exit(EXIT_FAILURE);
+	}
+}
+
+static int cgroup_mkdir(const char *name, int *offset)
+{
+	char *dir = NULL, *path = NULL, del;
+	int i = 0, ret = 0, y;
+	size_t size;
+
+	*offset = -1;
+
+	if (!name || !strcmp(name, "/"))
+		goto error;
+
+	dir = strdup(name);
+	if (!dir) {
+		log_error(PIN "cannot duplicate string [%s]", name);
+		ret = -1;
+		goto error;
+	}
+
+	size = strlen(ctrl.mount_point) + strlen(dir) + 1;
+	path = malloc(size);
+	if (!path) {
+		perror("malloc");
+		ret = -1;
+		goto error;
+	}
+
+	do {
+		y = i;
+
+		while (dir[i] == '/')
+			i++;
+
+		if (dir[i] == '\0')
+			goto error;
+
+		while (dir[i] != '\0' && dir[i] != '/')
+			i++;
+
+		del = dir[i];
+		dir[i] = '\0';
+
+		snprintf(path, size, "%s%s", ctrl.mount_point, dir);
+
+		ret = mkdir(path, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+		if (ret) {
+			switch (errno) {
+			case EEXIST:
+				log_debug(PIN "cgroup [%s] exists, continue ...", dir);
+				ret = 0;
+				goto next;
+			default:
+				log_error(PIN "cgroup [%s] unhandled error (%s)", dir, strerror(errno));
+				goto error;
+			}
+		} else if (*offset == -1) {
+			*offset = y;
+		}
+next:
+		dir[i] = del;
+	} while (dir[i]);
+error:
+	free(dir);
+	free(path);
+	return ret;
+}
+
+static int cgroup_rmdir(char *name, int offset)
+{
+	char *dir = NULL, *path = NULL, *del;
+	int ret = 0;
+	size_t size, last;
+
+	if (offset < 0)
+		goto error;
+
+	dir = strdup(name);
+	if (!dir) {
+		log_error(PIN "cannot duplicate string [%s]", name);
+		ret = -1;
+		goto error;
+	}
+
+	/* Remove trailing slashes. */
+	while (last = strlen(dir) - 1, dir[last] == '/')
+		dir[last] = '\0';
+
+	size = strlen(ctrl.mount_point) + strlen(dir) + 1;
+	path = malloc(size);
+	if (!path) {
+		perror("malloc");
+		ret = -1;
+		goto error;
+	}
+
+	while (1) {
+		snprintf(path, size, "%s%s", ctrl.mount_point, dir);
+
+		ret = rmdir(path);
+		if (ret) {
+			switch (errno) {
+			case ENOTEMPTY:
+				log_debug(PIN "cgroup [%s] not empty, continue ...", dir);
+				ret = 0;
+				break;
+			case EBUSY:
+				log_debug(PIN "cgroup [%s] is busy, continue ...", dir);
+				ret = 0;
+				break;
+			case ENOENT:
+				log_debug(PIN "cgroup [%s] doesn't exist, continue ...", dir);
+				ret = 0;
+				break;
+			default:
+				log_error(PIN "cgroup [%s] unhandled error (%s)", dir, strerror(errno));
+				break;
+			}
+			break;
+		}
+
+		del = strrchr(dir, '/');
+		if (!del)
+			break;
+		*del = '\0';
+
+		/* Remove trailing slashes and adapt delimiter. */
+		while (last = strlen(dir) - 1, dir[last] == '/') {
+			del = &dir[last];
+			*del = '\0';
+		}
+
+		if (del <= dir + offset)
+			break;
+	}
+error:
+	free(dir);
+	free(path);
+	return ret;
+}
+
+void add_cgroups(void)
+{
+	taskgroup_data_t *tg = ctrl.tg_array;
+	int i;
+
+	for (i = 0; i < ctrl.nr_tgs; i++, tg++) {
+		if (cgroup_mkdir(tg->name, &tg->offset)) {
+			log_critical(PIN "cannot create cgroup [%s]", tg->name);
+			exit(EXIT_FAILURE);
+		}
+		log_debug(PIN "cgroup [%s] added", tg->name);
+	}
+}
+
+void remove_cgroups(void)
+{
+	taskgroup_data_t *tg = &ctrl.tg_array[ctrl.nr_tgs - 1];
+	int i;
+
+	if (!ctrl.mount_point)
+		return;
+
+	for (i = ctrl.nr_tgs - 1; i >= 0; i--, tg--) {
+		if (cgroup_rmdir(tg->name, tg->offset)) {
+			log_critical(PIN "cannot remove cgroup [%s]", tg->name);
+			exit(EXIT_FAILURE);
+		}
+		log_debug(PIN "cgroup [%s] removed", tg->name);
+	}
+}

--- a/src/rt-app_taskgroups.h
+++ b/src/rt-app_taskgroups.h
@@ -5,6 +5,7 @@
 
 taskgroup_data_t *alloc_taskgroup(size_t size);
 taskgroup_data_t *find_taskgroup(char *name);
+void set_thread_taskgroup(thread_data_t *data, taskgroup_data_t *tg);
 
 void initialize_cgroups(void);
 void add_cgroups(void);

--- a/src/rt-app_taskgroups.h
+++ b/src/rt-app_taskgroups.h
@@ -6,6 +6,7 @@
 taskgroup_data_t *alloc_taskgroup(size_t size);
 taskgroup_data_t *find_taskgroup(char *name);
 void set_thread_taskgroup(thread_data_t *data, taskgroup_data_t *tg);
+void reset_thread_taskgroup(void);
 
 void initialize_cgroups(void);
 void add_cgroups(void);

--- a/src/rt-app_taskgroups.h
+++ b/src/rt-app_taskgroups.h
@@ -6,4 +6,8 @@
 taskgroup_data_t *alloc_taskgroup(size_t size);
 taskgroup_data_t *find_taskgroup(char *name);
 
+void initialize_cgroups(void);
+void add_cgroups(void);
+void remove_cgroups(void);
+
 #endif /* _RTAPP_TASKGROUPS_H */

--- a/src/rt-app_taskgroups.h
+++ b/src/rt-app_taskgroups.h
@@ -1,0 +1,9 @@
+#ifndef _RTAPP_TASKGROUPS_H
+#define _RTAPP_TASKGROUPS_H
+
+#include "rt-app_types.h"
+
+taskgroup_data_t *alloc_taskgroup(size_t size);
+taskgroup_data_t *find_taskgroup(char *name);
+
+#endif /* _RTAPP_TASKGROUPS_H */

--- a/src/rt-app_types.h
+++ b/src/rt-app_types.h
@@ -178,12 +178,18 @@ typedef struct _sched_data_t {
 	unsigned long period;
 } sched_data_t;
 
+typedef struct _taskgroup_data_t {
+	char *name;
+	int offset;
+} taskgroup_data_t;
+
 typedef struct _phase_data_t {
 	int loop;
 	event_data_t *events;
 	int nbevents;
 	cpuset_data_t cpu_data;
 	sched_data_t *sched_data;
+	taskgroup_data_t *taskgroup_data;
 } phase_data_t;
 
 typedef struct _thread_data_t {
@@ -198,6 +204,9 @@ typedef struct _thread_data_t {
 
 	sched_data_t *sched_data; /* scheduler policy information */
 	sched_data_t *curr_sched_data; /* current scheduler policy */
+
+	taskgroup_data_t *taskgroup_data; /* taskgroup information */
+	taskgroup_data_t *curr_taskgroup_data; /* current taskgroup */
 
 	int loop;
 	int nphases;

--- a/src/rt-app_utils.h
+++ b/src/rt-app_utils.h
@@ -113,10 +113,10 @@ timespec_sub_to_ns(struct timespec *t1, struct timespec *t2);
 void
 log_timing(FILE *handler, timing_point_t *t);
 
-#ifdef DLSCHED
 pid_t
 gettid(void);
 
+#ifdef DLSCHED
 __u64
 timespec_to_nsec(struct timespec *ts);
 #endif


### PR DESCRIPTION
The taskgroups support works currently for cgroupv1 (legacy)
hierarchies. It can be optionally configured by specifying
--with-taskgroups as a build parameter (see README.in).
A configuration example is given in doc/tutorial.txt.
For now an rt-app binary w/ taskgroup support only allows SCHED_NORMAL
policy. An rt-app binary w/o taskgroups support ignores any taskgroup
related name/value pairs in the json file.

Tested on x86_64 and arm64.

Signed-off-by: Dietmar Eggemann <dietmar.eggemann@arm.com>