### PR TITLE
utils: Fix timespec_to_nsec() return type

### DIFF
--- a/src/rt-app_utils.h
+++ b/src/rt-app_utils.h
@@ -117,7 +117,7 @@ log_timing(FILE *handler, timing_point_t *t);
 pid_t
 gettid(void);
 
-unsigned long long
+__u64
 timespec_to_nsec(struct timespec *ts);
 #endif
 


### PR DESCRIPTION
Align forward declaration and definition return types of timespec_
to_nsec() function, as current misalignment is problematic on some
archs.