### PR TITLE
rt-app: Add support for SCHED_IDLE policy

### DIFF
--- a/doc/tutorial.txt
+++ b/doc/tutorial.txt
@@ -194,6 +194,7 @@ otherwise the scheduling paraleters will stay unchanged
 * policy : String. Define the scheduling policy of the thread. default_policy
 is used if not defined. Accepted value are:
   - "SCHED_OTHER"
+  - "SCHED_IDLE"
   - "SCHED_RR"
   - "SCHED_FIFO"
   - "SCHED_DEADLINE"

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -843,11 +843,12 @@ static void set_thread_priority(thread_data_t *data, sched_data_t *sched_data)
 			break;
 
 		case other:
+		case idle:
 			log_debug("[%d] setting scheduler %s priority %d", data->ind,
 					policy_to_string(sched_data->policy), sched_data->prio);
 
 
-			if (sched_data->prio > 19 || sched_data->prio < -20) {
+			if ((sched_data->policy == other) && (sched_data->prio > 19 || sched_data->prio < -20)) {
 				log_critical("[%d] setpriority "
 					"%d nice invalid. "
 					"Valid between -20 and 19",
@@ -870,15 +871,17 @@ static void set_thread_priority(thread_data_t *data, sched_data_t *sched_data)
 				}
 			}
 
-			/* Set nice priority */
-			ret = setpriority(PRIO_PROCESS, 0,
-					sched_data->prio);
-			if (ret != 0) {
-				log_critical("[%d] setpriority "
-				     "returned %d", data->ind, ret);
-				errno = ret;
-				perror("setpriority");
-				exit(EXIT_FAILURE);
+			if (sched_data->policy == other) {
+				/* Set nice priority */
+				ret = setpriority(PRIO_PROCESS, 0,
+						sched_data->prio);
+				if (ret != 0) {
+					log_critical("[%d] setpriority "
+					     "returned %d", data->ind, ret);
+					errno = ret;
+					perror("setpriority");
+					exit(EXIT_FAILURE);
+				}
 			}
 
 			data->lock_pages = 0; /* forced off for SCHED_OTHER */

--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -742,7 +742,7 @@ static sched_data_t *parse_sched_data(struct json_object *obj, int def_policy)
 	/* Get priority */
 	if (tmp_data.policy == -1)
 		prior_def = -1;
-	else if (tmp_data.policy == other)
+	else if (tmp_data.policy == other || tmp_data.policy == idle)
 		prior_def = DEFAULT_THREAD_NICE;
 	else
 		prior_def = DEFAULT_THREAD_PRIORITY;

--- a/src/rt-app_types.h
+++ b/src/rt-app_types.h
@@ -42,11 +42,17 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #define EXIT_INV_CONFIG 2
 #define EXIT_INV_COMMANDLINE 3
 
+/* SCHED_IDLE is not available if __USE_GNU is not defined */
+#ifndef __USE_GNU
+#define SCHED_IDLE 5
+#endif
+
 struct _thread_data_t;
 
 typedef enum policy_t
 {
 	other = SCHED_OTHER,
+	idle = SCHED_IDLE,
 	rr = SCHED_RR,
 	fifo = SCHED_FIFO
 #ifdef DLSCHED

--- a/src/rt-app_utils.c
+++ b/src/rt-app_utils.c
@@ -175,6 +175,8 @@ string_to_policy(const char *policy_name, policy_t *policy)
 {
 	if (strcmp(policy_name, "SCHED_OTHER") == 0)
 		*policy = other;
+	else if (strcmp(policy_name, "SCHED_IDLE") == 0)
+		*policy = idle;
 	else if (strcmp(policy_name, "SCHED_RR") == 0)
 		*policy =  rr;
 	else if (strcmp(policy_name, "SCHED_FIFO") == 0)
@@ -194,6 +196,8 @@ policy_to_string(policy_t policy)
 	switch (policy) {
 		case other:
 			return "SCHED_OTHER";
+		case idle:
+			return "SCHED_IDLE";
 		case rr:
 			return "SCHED_RR";
 		case fifo:


### PR DESCRIPTION
This adds support for SCHED_IDLE scheduling policy.

This locally defines SCHED_IDLE macro, which is incorrect but build was
failing without it and I am not sure how to fix that. The arch specific
sched.h headers (like /usr/include/aarch64-linux-gnu/bits/sched.h)
define them only if __USE_GNU is defined.

Signed-off-by: Viresh Kumar <viresh.kumar@linaro.org>