### PR TITLE
rt-app: add uclamp support

### DIFF
--- a/libdl/dl_syscalls.h
+++ b/libdl/dl_syscalls.h
@@ -74,22 +74,49 @@
 #define RLIMIT_DLDLINE		16
 #define RLIMIT_DLRTIME		17
 
+/*
+ * For the sched_{set,get}attr() calls
+ */
+#define SCHED_FLAG_RESET_ON_FORK        0x01
+#define SCHED_FLAG_RECLAIM              0x02
+#define SCHED_FLAG_DL_OVERRUN           0x04
+#define SCHED_FLAG_KEEP_POLICY          0x08
+#define SCHED_FLAG_KEEP_PARAMS          0x10
+#define SCHED_FLAG_UTIL_CLAMP_MIN       0x20
+#define SCHED_FLAG_UTIL_CLAMP_MAX       0x40
+
+#define SCHED_FLAG_KEEP_ALL 	(SCHED_FLAG_KEEP_POLICY | \
+				 SCHED_FLAG_KEEP_PARAMS)
+
+#define SCHED_FLAG_UTIL_CLAMP	(SCHED_FLAG_UTIL_CLAMP_MIN | \
+				 SCHED_FLAG_UTIL_CLAMP_MAX)
+
+#define SCHED_FLAG_ALL	(SCHED_FLAG_RESET_ON_FORK	| \
+			 SCHED_FLAG_RECLAIM		| \
+			 SCHED_FLAG_DL_OVERRUN		| \
+			 SCHED_FLAG_KEEP_ALL		| \
+			 SCHED_FLAG_UTIL_CLAMP)
+
 struct sched_attr {
 	__u32 size;
-	
+
 	__u32 sched_policy;
 	__u64 sched_flags;
-	
+
 	/* SCHED_NORMAL, SCHED_BATCH */
 	__s32 sched_nice;
-	
+
 	/* SCHED_FIFO, SCHED_RR */
 	__u32 sched_priority;
-	
+
 	/* SCHED_DEADLINE */
 	__u64 sched_runtime;
 	__u64 sched_deadline;
 	__u64 sched_period;
+
+	/* Utilization hints */
+	__u32 sched_util_min;
+	__u32 sched_util_max;
 };
 
 int sched_setattr(pid_t pid,

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -1010,12 +1010,18 @@ static void set_thread_priority(thread_data_t *data, sched_data_t *sched_data)
 			sa_params.sched_flags |= SCHED_FLAG_UTIL_CLAMP_MIN;
 			log_notice("[%d] setting util_min=%d",
 				   data->ind, sched_data->util_min);
+			log_ftrace(ft_data.marker_fd, FTRACE_ATTRS,
+				   "rtapp_attrs: event=uclamp util_min=%d",
+				   sched_data->util_min);
 		}
 		if (sched_data->util_max != -1) {
 			sa_params.sched_util_max = sched_data->util_max;
 			sa_params.sched_flags |= SCHED_FLAG_UTIL_CLAMP_MAX;
 			log_notice("[%d] setting util_max=%d",
 				   data->ind, sched_data->util_max);
+			log_ftrace(ft_data.marker_fd, FTRACE_ATTRS,
+				   "rtapp_attrs: event=uclamp util_max=%d",
+				   sched_data->util_max);
 		}
 
 		ret = sched_setattr(tid, &sa_params, flags);

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -854,7 +854,7 @@ static void set_thread_priority(thread_data_t *data, sched_data_t *sched_data)
 	struct sched_param param;
 	policy_t policy;
 #ifdef DLSCHED
-	struct sched_attr dl_params;
+	struct sched_attr sa_params;
 	pid_t tid;
 	unsigned int flags = 0;
 #endif
@@ -944,15 +944,15 @@ static void set_thread_priority(thread_data_t *data, sched_data_t *sched_data)
 					sched_data->runtime, sched_data->deadline);
 
 			tid = gettid();
-			dl_params.size = sizeof(struct sched_attr);
-			dl_params.sched_flags = 0;
-			dl_params.sched_policy = SCHED_DEADLINE;
-			dl_params.sched_priority = 0;
-			dl_params.sched_runtime = sched_data->runtime;
-			dl_params.sched_deadline = sched_data->deadline;
-			dl_params.sched_period = sched_data->period;
+			sa_params.size = sizeof(struct sched_attr);
+			sa_params.sched_flags = 0;
+			sa_params.sched_policy = SCHED_DEADLINE;
+			sa_params.sched_priority = 0;
+			sa_params.sched_runtime = sched_data->runtime;
+			sa_params.sched_deadline = sched_data->deadline;
+			sa_params.sched_period = sched_data->period;
 
-			ret = sched_setattr(tid, &dl_params, flags);
+			ret = sched_setattr(tid, &sa_params, flags);
 			if (ret != 0) {
 				log_critical("[%d] sched_setattr "
 						"returned %d", data->ind, ret);

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -878,6 +878,11 @@ static void set_thread_priority(thread_data_t *data, sched_data_t *sched_data)
 		case fifo:
 			log_debug("[%d] setting scheduler %s priority %d", data->ind,
 					policy_to_string(sched_data->policy), sched_data->prio);
+			log_ftrace(ft_data.marker_fd, FTRACE_ATTRS,
+				   "rtapp_attrs: event=policy policy=%s prio=%d",
+				   sched_data->policy == rr ? "rr" : "fifo",
+				   sched_data->prio);
+
 			param.sched_priority = sched_data->prio;
 			ret = pthread_setschedparam(pthread_self(),
 					sched_data->policy,
@@ -895,7 +900,10 @@ static void set_thread_priority(thread_data_t *data, sched_data_t *sched_data)
 		case idle:
 			log_debug("[%d] setting scheduler %s priority %d", data->ind,
 					policy_to_string(sched_data->policy), sched_data->prio);
-
+			log_ftrace(ft_data.marker_fd, FTRACE_ATTRS,
+				   "rtapp_attrs: event=policy policy=%s prio=%d",
+				   sched_data->policy == other ? "other" : "idle",
+				   sched_data->prio);
 
 			if ((sched_data->policy == other) && (sched_data->prio > 19 || sched_data->prio < -20)) {
 				log_critical("[%d] setpriority "
@@ -942,6 +950,10 @@ static void set_thread_priority(thread_data_t *data, sched_data_t *sched_data)
 					" period %lu", data->ind,
 					policy_to_string(sched_data->policy), sched_data->period,
 					sched_data->runtime, sched_data->deadline);
+			log_ftrace(ft_data.marker_fd, FTRACE_ATTRS,
+				   "rtapp_attrs: event=policy policy=dl runtime=%lu deadline=%lu period=%lu",
+				   sched_data->prio, sched_data->runtime,
+				   sched_data->deadline, sched_data->period);
 
 			tid = gettid();
 			sa_params.size = sizeof(struct sched_attr);

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -970,6 +970,34 @@ static void set_thread_priority(thread_data_t *data, sched_data_t *sched_data)
 			exit(EXIT_FAILURE);
 	}
 
+	if (sched_data->policy != deadline &&
+	    (sched_data->util_min != -1 || sched_data->util_max != -1)) {
+		sa_params.size = sizeof(struct sched_attr);
+		sa_params.sched_flags = SCHED_FLAG_KEEP_ALL;
+		tid = gettid();
+
+		if (sched_data->util_min != -1) {
+			sa_params.sched_util_min = sched_data->util_min;
+			sa_params.sched_flags |= SCHED_FLAG_UTIL_CLAMP_MIN;
+			log_notice("[%d] setting util_min=%d",
+				   data->ind, sched_data->util_min);
+		}
+		if (sched_data->util_max != -1) {
+			sa_params.sched_util_max = sched_data->util_max;
+			sa_params.sched_flags |= SCHED_FLAG_UTIL_CLAMP_MAX;
+			log_notice("[%d] setting util_max=%d",
+				   data->ind, sched_data->util_max);
+		}
+
+		ret = sched_setattr(tid, &sa_params, flags);
+		if (ret != 0) {
+			log_critical("[%d] sched_setattr returned %d",
+				     data->ind, ret);
+			perror("sched_setattr: failed to set uclamp value(s)");
+			exit(EXIT_FAILURE);
+		}
+	}
+
 	data->curr_sched_data = sched_data;
 }
 

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -976,6 +976,23 @@ static void set_thread_priority(thread_data_t *data, sched_data_t *sched_data)
 		sa_params.sched_flags = SCHED_FLAG_KEEP_ALL;
 		tid = gettid();
 
+		/*
+		 * Currently we cannot use the syscall to set a clamp
+		 * value without specifing a valid policy and priotiry.
+		 * Read the current values and use them for the following
+		 * syscall.
+		 * TODO: fix __sched_setscheduler() to get rid of this!
+		 */
+		ret = sched_getattr(tid, &sa_params,
+				    sizeof(struct sched_attr), flags);
+		if (ret != 0) {
+			log_critical("[%d] sched_getattr returned %d",
+					data->ind, ret);
+			errno = ret;
+			perror("sched_getattr");
+			exit(EXIT_FAILURE);
+		}
+
 		if (sched_data->util_min != -1) {
 			sa_params.sched_util_min = sched_data->util_min;
 			sa_params.sched_flags |= SCHED_FLAG_UTIL_CLAMP_MIN;

--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -819,6 +819,19 @@ static sched_data_t *parse_sched_data(struct json_object *obj, int def_policy)
 	tmp_data.period = get_int_value_from(obj, "dl-period", TRUE, tmp_data.runtime);
 	tmp_data.deadline = get_int_value_from(obj, "dl-deadline", TRUE, tmp_data.period);
 
+	/* clamping params (-1: no changes ) */
+	tmp_data.util_min = get_int_value_from(obj, "util_min", TRUE, -1);
+	if (tmp_data.util_min != -1 && tmp_data.util_min > 1024) {
+		log_critical(PIN2 "Invalid util_min %d (>1024)", tmp_data.util_min);
+		exit(EXIT_INV_CONFIG);
+	}
+	tmp_data.util_max = get_int_value_from(obj, "util_max", TRUE, -1);
+	if (tmp_data.util_max != -1 && tmp_data.util_max > 1024) {
+		log_critical(PIN2 "Invalid util_max %d (>1024)", tmp_data.util_max);
+		exit(EXIT_INV_CONFIG);
+	}
+	log_notice(PIN2 "util_min: %d, util_max: %d",
+		   tmp_data.util_min, tmp_data.util_max);
 
 	if (def_policy != -1) {
 		/* Support legacy grammar for thread object */
@@ -837,7 +850,8 @@ static sched_data_t *parse_sched_data(struct json_object *obj, int def_policy)
 
 	/* Check if we found at least one meaningful scheduler parameter */
 	if (tmp_data.prio != -1 ||
-	    tmp_data.runtime || tmp_data.period || tmp_data.deadline) {
+	    tmp_data.runtime || tmp_data.period || tmp_data.deadline ||
+	    tmp_data.util_min != -1 || tmp_data.util_max != -1) {
 		sched_data_t *new_data;
 
 		/* At least 1 parameters has been set in the object */

--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -836,7 +836,8 @@ static sched_data_t *parse_sched_data(struct json_object *obj, int def_policy)
 	tmp_data.deadline *= 1000;
 
 	/* Check if we found at least one meaningful scheduler parameter */
-	if (tmp_data.prio != -1 || tmp_data.runtime || tmp_data.period || tmp_data.period) {
+	if (tmp_data.prio != -1 ||
+	    tmp_data.runtime || tmp_data.period || tmp_data.deadline) {
 		sched_data_t *new_data;
 
 		/* At least 1 parameters has been set in the object */

--- a/src/rt-app_types.h
+++ b/src/rt-app_types.h
@@ -177,6 +177,8 @@ typedef struct _sched_data_t {
 	unsigned long runtime;
 	unsigned long deadline;
 	unsigned long period;
+	int util_min;
+	int util_max;
 } sched_data_t;
 
 typedef struct _taskgroup_data_t {

--- a/src/rt-app_utils.h
+++ b/src/rt-app_utils.h
@@ -57,6 +57,7 @@ do {									\
 #define FTRACE_LOOP	0x04
 #define FTRACE_EVENT	0x08
 #define FTRACE_STATS	0x10
+#define FTRACE_ATTRS	0x20
 
 #define log_ftrace(mark_fd, level, msg, args...)			\
 do {									\


### PR DESCRIPTION
Utilization clamping allows to set task-specific utilization clamp
values, for SCHED_OTHER and SCHED_{FIFO,RR}, via the sched_setattr(2)
syscall.

Core bits and per-task API has been added to the Linux kernel in version v5.3:
   https://lore.kernel.org/lkml/20190621084217.8167-1-patrick.bellasi@arm.com/

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>