### PR TITLE
rtapp: Force update date/build_version on autoreconf

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-autoreconf --install --symlink || exit 1
+autoreconf --force --install --symlink || exit 1
 
 echo
 echo "----------------------------------------------------------------"


### PR DESCRIPTION
The BUILD_DATE and VERSION are generated when the configure script is
created. However, by default autoreconf only remakes those files that
are older than their sources. Thus, when we add some new patches on an
already existing rt-app tree (i.e. without touching configure.in) a new
build does not get an updated "--version" output.

Force autoreconf to consider all files obsolete, so that every new:

   autogen.sh && configure && make

cycle generates updated version strings.

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>