### PR TITLE
rtapp/config: Fix "ftrace" for backward support

### DIFF
--- a/doc/examples/browser-long.json
+++ b/doc/examples/browser-long.json
@@ -123,7 +123,6 @@
 	"global" : {
 		"default_policy" : "SCHED_OTHER",
 		"duration" : 600,
-		"ftrace" : "none",
 		"gnuplot" : false,
 		"logdir" : "./",
 		"log_basename" : "web",

--- a/doc/examples/browser-short.json
+++ b/doc/examples/browser-short.json
@@ -123,7 +123,6 @@
 	"global" : {
 		"default_policy" : "SCHED_OTHER",
 		"duration" : 6,
-		"ftrace" : "none",
 		"gnuplot" : false,
 		"logdir" : "./",
 		"log_basename" : "web",

--- a/doc/examples/cpufreq_governor_efficiency/calibration.json
+++ b/doc/examples/cpufreq_governor_efficiency/calibration.json
@@ -19,7 +19,6 @@
 		"default_policy" : "SCHED_FIFO",
 		"calibration" : "CPU0",
 		"lock_pages" : true,
-		"ftrace" : "none",
 		"logdir" : "./",
 	}
 }

--- a/doc/examples/cpufreq_governor_efficiency/dvfs.json
+++ b/doc/examples/cpufreq_governor_efficiency/dvfs.json
@@ -21,7 +21,6 @@
 		"default_policy" : "SCHED_OTHER",
 		"calibration" : 128,
 		"lock_pages" : true,
-		"ftrace" : "none",
 		"logdir" : "./",
 		"log_size" : 2,
 	}

--- a/doc/examples/mp3-long.json
+++ b/doc/examples/mp3-long.json
@@ -57,7 +57,6 @@
 	"global" : {
 		"default_policy" : "SCHED_OTHER",
 		"duration" : 600,
-		"ftrace" : "none",
 		"gnuplot" : false,
 		"logdir" : "./",
 		"log_basename" : "mp3",

--- a/doc/examples/mp3-short.json
+++ b/doc/examples/mp3-short.json
@@ -57,7 +57,6 @@
 	"global" : {
 		"default_policy" : "SCHED_OTHER",
 		"duration" : 6,
-		"ftrace" : "none",
 		"gnuplot" : false,
 		"logdir" : "./",
 		"log_basename" : "mp3",

--- a/doc/examples/video-long.json
+++ b/doc/examples/video-long.json
@@ -240,7 +240,6 @@
 	"global" : {
 		"default_policy" : "SCHED_OTHER",
 		"duration" : 600,
-		"ftrace" : "none",
 		"gnuplot" : false,
 		"logdir" : "./",
 		"log_basename" : "video",

--- a/doc/examples/video-short.json
+++ b/doc/examples/video-short.json
@@ -240,7 +240,6 @@
 	"global" : {
 		"default_policy" : "SCHED_OTHER",
 		"duration" : 6,
-		"ftrace" : "none",
 		"gnuplot" : false,
 		"logdir" : "./",
 		"log_basename" : "video",

--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -132,7 +132,9 @@ check_type_is(struct json_object *where,
 	      const char *key,
 	      enum json_type type)
 {
-	struct json_object *value = get_in_object(where, key, FALSE);
+	struct json_object *value = get_in_object(where, key, TRUE);
+	if (!value)
+		return false;
 	return json_object_is_type(value, type);
 }
 


### PR DESCRIPTION
The "ftrace" JSON option has always been considered optional and, by default, no
ftrace events was genererated if that option was not specified.

With the addition of the ftrace category support in:

   commit a2d7d8c571eb ("ftrace: Add support for ftrace categories and make them easy to parse")

and specifically with code to grant backward compatibility for the now
deprecated bool type, the JSON parser complains if a value for "ftrace" is not
specified, thus failing to be completely backward compatibile.

Fix that by adding a check on "ftrace" missing and allowing the code to smoothly
fall-back to the default behavior.

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>