### PR TITLE
[RFC] Improve busy loop stability

### DIFF
--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -196,8 +196,11 @@ static int create_thread(const thread_data_t *td, int index, int forked, int nfo
 /*
  * Function: to do some useless operation.
  * TODO: improve the waste loop with more heavy functions
+ *
+ * This function must be protected against compiler optimizations, as it is
+ * somewhat pure and has not result.
  */
-void waste_cpu_cycles(unsigned long long load_loops)
+void __attribute__((noinline, optimize("O0"))) waste_cpu_cycles(unsigned long long load_loops)
 {
 	double param, result;
 	double n;
@@ -206,6 +209,13 @@ void waste_cpu_cycles(unsigned long long load_loops)
 	param = 0.95;
 	n = 4;
 	for (i = 0 ; i < load_loops ; i++) {
+		/*
+		 * Add a "side-effect" to that function, so compilers will not
+		 * try to remove the call to it altogether. See GCC
+		 * documentation of "noinline" function attribute for details.
+		 */
+		asm("");
+
 		result = ldexp(param , (ldexp(param , ldexp(param , n))));
 		result = ldexp(param , (ldexp(param , ldexp(param , n))));
 		result = ldexp(param , (ldexp(param , ldexp(param , n))));

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -206,6 +206,12 @@ void __attribute__((noinline, optimize("O0"))) waste_cpu_cycles(unsigned long lo
 	double n;
 	unsigned long long i;
 
+	/*
+	 * Adjust the number of loops to get calibration values close to what
+	 * they used to be with the previous loop body.
+	 */
+	load_loops *= 10;
+
 	param = 0.95;
 	n = 4;
 	for (i = 0 ; i < load_loops ; i++) {
@@ -215,11 +221,7 @@ void __attribute__((noinline, optimize("O0"))) waste_cpu_cycles(unsigned long lo
 		 * documentation of "noinline" function attribute for details.
 		 */
 		asm("");
-
-		result = ldexp(param , (ldexp(param , ldexp(param , n))));
-		result = ldexp(param , (ldexp(param , ldexp(param , n))));
-		result = ldexp(param , (ldexp(param , ldexp(param , n))));
-		result = ldexp(param , (ldexp(param , ldexp(param , n))));
+		result = n/i;
 	}
 	return;
 }


### PR DESCRIPTION
The current implementation of the busy loop seems to lead to somehow non-reproducible calibration values, and also potentially different duty cycle when the same workload is executed twice. Old versions of rt-app seem to behave well, but for some reason building a recent version with the same toolchain leads to these issues.

In order to solve that:
* Shield the busy loop against compiler optimizations, since the function is "useless". It's cheap to do and should avoid future pain.
* Use a simpler loop body that avoids branches to other functions. Hopefully, the behaviour of such body should stay the same in the future.

This PR will however change the behavior of rt-app on asymmetric systems with so called CPU PELT invariance. The invariance described by CPU capacities only holds for a given mix of instructions. Since the CPU capacities have typically been established using a benchmark X (supposedly Dhrystone), the duty cycle of any other periodic workload will scale differently when moved around on different CPUs. Changing the rt-app loop body will therefore change the utilization of the task when running on a little CPU. This can be accounted for when creating the JSON when the task will be pinned on a given class of CPUs, but there is no real solution when the task is free to move on any CPU.

Since there is no way of actually ensuring that rt-app calibration values will be inversely proportional to CPU capacities, it's a lost battle so IMO we should aim at getting reproducible results. People interested in reproducing very accurate util signals should update the in-kernel capacities of their CPUs based on rt-app calibration values before running their tests.

Fixes https://github.com/scheduler-tools/rt-app/issues/89