### PR TITLE
rt-app:config: remove spurious log_notice

### DIFF
--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -832,8 +832,6 @@ static sched_data_t *parse_sched_data(struct json_object *obj, int def_policy)
 		log_critical(PIN2 "Invalid util_max %d (>1024)", tmp_data.util_max);
 		exit(EXIT_INV_CONFIG);
 	}
-	log_notice(PIN2 "util_min: %d, util_max: %d",
-		   tmp_data.util_min, tmp_data.util_max);
 
 	if (def_policy != -1) {
 		/* Support legacy grammar for thread object */


### PR DESCRIPTION
rt-app displays the spurious and useless :
  [rt-app] <notice> [json]         util_min: -1, util_max: -1
for each and every threads node that is parsed even if no clamp values
have been specified in the json node.

Remove this useless print

Signed-off-by: Vincent Guittot <vincent.guittot@linaro.org>