### PR TITLE
Added strict event length match

### DIFF
--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -743,7 +743,8 @@ obj_is_event(char *name)
 
     for (pos = events; *pos; pos++) {
 	    char *event = *pos;
-	    if (!strncmp(name, event, strlen(event)))
+	    if (strlen(event) == strlen(name) &&
+	    		!strncmp(name, event, strlen(event)))
 		    return 1;
     }
 


### PR DESCRIPTION
This fix will guarantee exact match of "special" keys such as:
"lock", "unlock", "wait", "signal", etc.
This will help to prevent accidental matches like:
"mem" and "membind_nodes"