### PR TITLE
rt-app: Fix sched_setattr() failures with older kernels

### DIFF
--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -902,7 +902,7 @@ static void set_thread_priority(thread_data_t *data, sched_data_t *sched_data)
 {
 	struct sched_param param;
 	policy_t policy;
-	struct sched_attr sa_params;
+	struct sched_attr sa_params = {0};
 	pid_t tid;
 	unsigned int flags = 0;
 	int ret;


### PR DESCRIPTION
When running rt-app on older android kernels (4.19 and before),
sched_setattr() syscall fails with -E2BIG error code. These kernels
don't have uclamp support. The kernel returns an error when the
new fields (in this case uclamp attributes) not known to kernel
are non zero. To fix this initialize the sched_attr structure to 0.

Signed-off-by: Pavankumar Kondeti <pkondeti@codeaurora.org>