### PR TITLE
Fix gnuplot logs file name for single thread task

### DIFF
--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -1401,22 +1401,12 @@ static void setup_main_gnuplot(void)
 			"plot ", tmp);
 
 		for (i=0; i<running_threads; i++) {
-			if (opts.nthreads == opts.num_tasks) {
-				fprintf(gnuplot_script,
-					"\"%s-%s.log\" u ($5/1000):4 w l"
-					" title \"thread [%s] (%s)\"",
-					opts.logbasename, threads[i].data->name,
-					threads[i].data->name,
-					policy_to_string(threads[i].data->sched_data->policy));
-			} else {
-				fprintf(gnuplot_script,
-					"\"%s-%s-%d.log\" u ($5/1000):4 w l"
-					" title \"thread [%s] (%s)\"",
-					opts.logbasename, threads[i].data->name,
-					threads[i].data->ind,
-					threads[i].data->name,
-					policy_to_string(threads[i].data->sched_data->policy));
-			}
+			fprintf(gnuplot_script,
+				"\"%s-%s.log\" u ($5/1000):4 w l"
+				" title \"thread [%s] (%s)\"",
+				opts.logbasename, threads[i].data->name,
+				threads[i].data->name,
+				policy_to_string(threads[i].data->sched_data->policy));
 
 			if ( i == nthreads-1)
 				fprintf(gnuplot_script, "\n");
@@ -1446,22 +1436,12 @@ static void setup_main_gnuplot(void)
 			"plot ", tmp);
 
 		for (i=0; i<running_threads; i++) {
-			if (opts.nthreads == opts.num_tasks) {
-				fprintf(gnuplot_script,
-					"\"%s-%s.log\" u ($5/1000):3 w l"
-					" title \"thread [%s] (%s)\"",
-					opts.logbasename, threads[i].data->name,
-					threads[i].data->name,
-					policy_to_string(threads[i].data->sched_data->policy));
-			} else {
-				fprintf(gnuplot_script,
-					"\"%s-%s-%d.log\" u ($5/1000):3 w l"
-					" title \"thread [%s] (%s)\"",
-					opts.logbasename, threads[i].data->name,
-					threads[i].data->ind,
-					threads[i].data->name,
-					policy_to_string(threads[i].data->sched_data->policy));
-			}
+			fprintf(gnuplot_script,
+				"\"%s-%s.log\" u ($5/1000):3 w l"
+				" title \"thread [%s] (%s)\"",
+				opts.logbasename, threads[i].data->name,
+				threads[i].data->name,
+				policy_to_string(threads[i].data->sched_data->policy));
 
 			if ( i == nthreads-1)
 				fprintf(gnuplot_script, "\n");

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -1401,13 +1401,22 @@ static void setup_main_gnuplot(void)
 			"plot ", tmp);
 
 		for (i=0; i<running_threads; i++) {
-			fprintf(gnuplot_script,
-				"\"%s-%s-%d.log\" u ($5/1000):4 w l"
-				" title \"thread [%s] (%s)\"",
-				opts.logbasename, threads[i].data->name,
-				threads[i].data->ind,
-				threads[i].data->name,
-				policy_to_string(threads[i].data->sched_data->policy));
+			if (opts.nthreads == opts.num_tasks) {
+				fprintf(gnuplot_script,
+					"\"%s-%s.log\" u ($5/1000):4 w l"
+					" title \"thread [%s] (%s)\"",
+					opts.logbasename, threads[i].data->name,
+					threads[i].data->name,
+					policy_to_string(threads[i].data->sched_data->policy));
+			} else {
+				fprintf(gnuplot_script,
+					"\"%s-%s-%d.log\" u ($5/1000):4 w l"
+					" title \"thread [%s] (%s)\"",
+					opts.logbasename, threads[i].data->name,
+					threads[i].data->ind,
+					threads[i].data->name,
+					policy_to_string(threads[i].data->sched_data->policy));
+			}
 
 			if ( i == nthreads-1)
 				fprintf(gnuplot_script, "\n");
@@ -1437,13 +1446,22 @@ static void setup_main_gnuplot(void)
 			"plot ", tmp);
 
 		for (i=0; i<running_threads; i++) {
-			fprintf(gnuplot_script,
-				"\"%s-%s-%d.log\" u ($5/1000):3 w l"
-				" title \"thread [%s] (%s)\"",
-				opts.logbasename, threads[i].data->name,
-				threads[i].data->ind,
-				threads[i].data->name,
-				policy_to_string(threads[i].data->sched_data->policy));
+			if (opts.nthreads == opts.num_tasks) {
+				fprintf(gnuplot_script,
+					"\"%s-%s.log\" u ($5/1000):3 w l"
+					" title \"thread [%s] (%s)\"",
+					opts.logbasename, threads[i].data->name,
+					threads[i].data->name,
+					policy_to_string(threads[i].data->sched_data->policy));
+			} else {
+				fprintf(gnuplot_script,
+					"\"%s-%s-%d.log\" u ($5/1000):3 w l"
+					" title \"thread [%s] (%s)\"",
+					opts.logbasename, threads[i].data->name,
+					threads[i].data->ind,
+					threads[i].data->name,
+					policy_to_string(threads[i].data->sched_data->policy));
+			}
 
 			if ( i == nthreads-1)
 				fprintf(gnuplot_script, "\n");


### PR DESCRIPTION
Wrong logs file when using gnuplot. Taking as reference the following config file:
```
{
  "tasks": {
    "task3": {
      "runtime": 3000,
      "timer": {
        "period": 1000000,
        "mode": "absolute",
        "ref": "unique"
      }
    },
    "task1": {
      "runtime": 19000,
      "timer": {
        "period": 1000000,
        "mode": "absolute",
        "ref": "unique"
      }
    }
  },
  "global": {
    "duration": 2,
    "default_policy": "SCHED_DEADLINE",
    "pi_enabled": false,
    "lock_pages": false,
    "logdir": "./rtapp-log",
    "log_basename": "rt-app",
    "log_mode": "file",
    "gnuplot": true
  }
}
```
The names of the log files are: `rt-app-task1-1.log  rt-app-task3-0.log`, but taking a look at the `rt-app-period.plot` file we have: 
```
plot "rt-app-task3-0-0.log" u ($5/1000):4 w l title "thread [task3-0] (SCHED_DEADLINE)", "rt-app-task1-1-1.log" u ($5/1000):4 w l title "thread [task1-1] (SCHED_DEADLINE)"
```