### PR TITLE
Fix how period is taken from timer

### DIFF
--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -881,8 +881,17 @@ static sched_data_t *parse_sched_data(struct json_object *obj, int def_policy)
 		/* Support legacy grammar for thread object */
 		if (!tmp_data.runtime)
 			tmp_data.runtime = get_int_value_from(obj, "runtime", TRUE, 0);
-		if (!tmp_data.period)
-			tmp_data.period = get_int_value_from(obj, "period", TRUE, tmp_data.runtime);
+
+		if (!tmp_data.period) {
+			struct lh_entry *entry; char *key; struct json_object *val; int idx;
+			foreach(obj, entry, key, val, idx) {
+				if (!strncmp(key, "timer", strlen("timer"))) {
+					tmp_data.period = get_int_value_from(val, "period", TRUE, tmp_data.runtime);
+					break;
+				}
+			}
+		}
+		
 		if (!tmp_data.deadline)
 			tmp_data.deadline = get_int_value_from(obj, "deadline", TRUE, tmp_data.period);
 	}


### PR DESCRIPTION
The period was not correctly extracted from the timer of the task. The period was extracted from the task object, which has no period object (according to the doc). Therefore the period was the same as the runtime which leads to an error using SCHED_DEADLINE. This problem has been exposed in https://github.com/scheduler-tools/rt-app/issues/38#issuecomment-646639431. In order to understand the problem let's consider the following config file:
```
{
  "tasks": {
    "task3": {
      "runtime": 233,
      "timer": {
        "period": 1000,
        "mode": "absolute",
        "ref": "unique"
      }
    },
    "task4": {
      "runtime": 115,
      "timer": {
        "period": 1000,
        "mode": "absolute",
        "ref": "unique"
      }
    },
    "task0": {
      "runtime": 123,
      "timer": {
        "period": 1000,
        "mode": "absolute",
        "ref": "unique"
      }
    },
    "task2": {
      "runtime": 128,
      "timer": {
        "period": 1000,
        "mode": "absolute",
        "ref": "unique"
      }
    },
    "task1": {
      "runtime": 151,
      "timer": {
        "period": 1000,
        "mode": "absolute",
        "ref": "unique"
      }
    }
  },
  "global": {
    "duration": 2,
    "default_policy": "SCHED_DEADLINE",
    "pi_enabled": false,
    "lock_pages": false,
    "logdir": "./rtapp-log",
    "log_basename": "rt-app",
    "log_mode": "file",
    "gnuplot": false
  }
}
```
Since the period is inside the timer and both `dl-runtime` and `dl-period` were not set, in the "old" code the period is equal to the task runtime which end up in utilization equal 1 for each task. In the issue I said that the config worked only  with N_TASK <= NCPUS - 1 because, if we consider the default parameter of `sched_rt_period_us` (1000000) and `sched_rt_runtime_us` (950000), for two cpus we have that the max utilization allowed by SCHED_DEADLINE is `2 * sched_rt_runtime_us / sched_rt_period_us` that is equal to 1,9. Since each task has U = 1 the config worked, in this case, with only one task. 
I'm not sure if that was desired behaviour, maybe the point was to use `dl-runtime` and `dl-period` but with the default config it does not work properly.  