### PR TITLE
config: parse_task_event_data(): Bail on malformed config

### DIFF
--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -709,10 +709,8 @@ parse_task_event_data(char *name, struct json_object *obj,
 	log_error(PIN2 "Please check the resource name or the resource section");
 
 unknown_event:
-	data->duration = 0;
-	data->type = rtapp_run;
-	log_error(PIN2 "Unknown or mismatch %s event type !!!", name);
-
+	log_critical(PIN2 "Unknown or mismatch %s event type !!!", name);
+	exit(EXIT_INV_CONFIG);
 }
 
 static char *events[] = {


### PR DESCRIPTION
When the JSON configuration is not matching the expected schema, the
current behavior is to print an error log and carry on with a 0-duration
run event. This is quite harmful as execution therefore continues
(potentially unnoticed), with a workload that is not at all what the
user wanted.

This is especially important when:
* many phases are involved. The error can be lost in the flow
* on automated setups: if no one is there to watch the log, critical
  errors like malformed input must be translated to a negative exit
  status.

Since there is no valid reason to provide an ill-formed (and therefore
meaningless) input, exit when this case is detected, which will make the
problem obvious to the user.

closes https://github.com/scheduler-tools/rt-app/issues/82