### PR TITLE
Alpine linux fixes

### DIFF
--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -563,7 +563,7 @@ static int run_event(event_data_t *event, int dry_run,
 	case rtapp_yield:
 		{
 			log_debug("yield %d", event->count);
-			pthread_yield();
+			sched_yield();
 		}
 		break;
 	case rtapp_fork:

--- a/src/rt-app_types.h
+++ b/src/rt-app_types.h
@@ -22,6 +22,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #ifndef _RTAPP_TYPES_H_
 #define _RTAPP_TYPES_H_
 
+/* For cpu_set_t type */
+#define _GNU_SOURCE
+#include <sched.h>
+
 #include <pthread.h>
 #include <limits.h>
 #include "config.h"


### PR DESCRIPTION
Some build errors prevented building rt-app in Alpine Linux. These modifications should allow building.