### PR TITLE
ftrace_log: Add override for tracefs location

### DIFF
--- a/doc/tutorial.txt
+++ b/doc/tutorial.txt
@@ -92,6 +92,11 @@ The category names currently supported are:
 
 Default value is "none".
 
+* ftracedir : String. Prefix used to find tracefs. Defaults to
+"/sys/kernel/debug" if not specified. In that case, we expect to find tracing
+controls inside "/sys/kernel/debug/tracing/". Has no effect if ftrace is not
+enabled.
+
 * gnuplot : Boolean. If True, it will create a gnu plot compatible file for
 each threads (see gnuplot section for more details). Default value is False.
 

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -64,7 +64,6 @@ static pthread_mutex_t joining_mutex;
 static pthread_mutex_t fork_mutex;
 
 static ftrace_data_t ft_data = {
-	.debugfs = "/sys/kernel/debug",
 	.marker_fd = -1,
 };
 
@@ -1542,7 +1541,7 @@ int main(int argc, char* argv[])
 	if (ftrace_level != FTRACE_NONE) {
 		log_notice("configuring ftrace");
 		// check if tracing is enabled
-		strcpy(tmp, ft_data.debugfs);
+		strcpy(tmp, opts.ftracedir);
 		strcat(tmp, "/tracing/tracing_on");
 		int ftrace_f = open(tmp, O_RDONLY);
 		if (ftrace_f < 0){
@@ -1557,7 +1556,7 @@ int main(int argc, char* argv[])
 		}
 		close(ftrace_f);
 		// set the marker
-		strcpy(tmp, ft_data.debugfs);
+		strcpy(tmp, opts.ftracedir);
 		strcat(tmp, "/tracing/trace_marker");
 		ft_data.marker_fd = open(tmp, O_WRONLY);
 		if (ft_data.marker_fd < 0) {

--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -40,6 +40,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #define JSON_FILE_BUF_SIZE 4096
 #define DEFAULT_MEM_BUF_SIZE (4 * 1024 * 1024)
 
+#define DEFAULT_FTRACE_DIR "/sys/kernel/debug"
+
 #ifndef TRUE
 #define TRUE true
 #define FALSE false
@@ -1207,6 +1209,7 @@ parse_global(struct json_object *global, rtapp_options_t *opts)
 		opts->io_device = strdup("/dev/null");
 		opts->mem_buffer_size = DEFAULT_MEM_BUF_SIZE;
 		opts->cumulative_slack = 0;
+		opts->ftracedir = strdup(DEFAULT_FTRACE_DIR);
 		return;
 	}
 
@@ -1304,6 +1307,7 @@ parse_global(struct json_object *global, rtapp_options_t *opts)
 	    log_critical(PFX "Invalid ftrace categories");
 	    exit(EXIT_INV_CONFIG);
 	}
+	opts->ftracedir = get_string_value_from(global, "ftracedir", TRUE, DEFAULT_FTRACE_DIR);
 
 	opts->lock_pages = get_bool_value_from(global, "lock_pages", TRUE, 1);
 	opts->pi_enabled = get_bool_value_from(global, "pi_enabled", TRUE, 0);

--- a/src/rt-app_types.h
+++ b/src/rt-app_types.h
@@ -289,6 +289,8 @@ typedef struct _rtapp_options_t {
 	char *io_device;
 
 	int cumulative_slack;
+
+	char *ftracedir;
 } rtapp_options_t;
 
 typedef struct _timing_point_t {


### PR DESCRIPTION
It's possible to mount tracefs in other locations - the Google Pixel 6,
for example, mounts tracefs at /sys/kernel/tracing rather than the
typical location inside debugfs at /sys/kernel/debug/tracing and disallows
debugfs from being mounted when running any GKI kernel.

This change allows configurations to select the location where rt-app
will attempt to configure tracing when enabled. If it is not supplied,
then the intended behaviour is that the existing default should be used.

There should not be any impact on existing json files running on existing
systems.

Signed-off-by: "Chris Redpath" <chris.redpath@arm.com>