### PR TITLE
Add sched_runtime support for SCHED_OTHER

### DIFF
--- a/doc/examples/custom-slice.json
+++ b/doc/examples/custom-slice.json
@@ -1,0 +1,33 @@
+{
+	/*
+	 * Simple use case setting the custom slice value on a SCHED_OTHER
+	 * task (thread0) via the runtime parameter. This runs alongside a
+	 * SCHED_DEADLINE task with its own sched_runtime value.
+	 * The workload runs for 2s until the use case is stopped with Ctrl+C
+	 */
+	"tasks" : {
+		"thread0" : {
+			"loop" : -1,
+			"run" :   20000,
+			"policy" : "SCHED_OTHER",
+			"priority" : -19, /* This is actually the NICE value */
+			"dl-runtime" : 100000
+		},
+		"thread1" : {
+			"loop" : -1,
+			"run" :   20000,
+			"policy" : "SCHED_DEADLINE",
+			"dl-runtime" : 200000
+		}
+	},
+	"global" : {
+		"duration" : 2,
+		"calibration" : "CPU0",
+		"pi_enabled" : false,
+		"lock_pages" : false,
+		"logdir" : "./",
+		"log_basename" : "rt-app1",
+		"ftrace" : "main,task,loop,event",
+		"gnuplot" : true,
+	}
+}

--- a/doc/tutorial.txt
+++ b/doc/tutorial.txt
@@ -222,6 +222,9 @@ Default value is 0. The unit is usec.  For backward compatibility, the
 key "runtime" will also be checked in thread object but special must be taken
 as this can conflict with runtime event.
 
+Since Linux 6.12 this parameter also applies to the SCHED_OTHER scheduling
+class. It is used to request a custom slice length for the thread.
+
 * dl-period : Integer. Define the period duration for deadline scheduling class.
 Default value is runtime. The unit is usec. For backward compatibility, the
 key "period" will also be checked in thread object.


### PR DESCRIPTION
Kernels starting with 6.12 have a new feature which allows requesting
a custom slice length on a task while using one of `SCHED_OTHER`,
`SCHED_BATCH` or `SCHED_EXT`. The interface was created by reusing the
existing `sched_attr::sched_runtime` parameter.

Similarly, this patch series reuses the existing interface (dl-runtime)
to allow users to experiment with the new custom slice feature.

Test output (kernel 6.13.0-rc1-00060-g7d9da040575b):

    rt-app -l 100 doc/examples/custom-slice.json

    [rt-app] <notice> [0] Starting with SCHED_OTHER policy with priority -19
    [rt-app] <notice> [1] Starting with SCHED_DEADLINE policy with priority 0
    [rt-app] <debug> [0] setting scheduler SCHED_OTHER nice=-19 runtime=100000000
    [rt-app] <debug> [1] setting scheduler SCHED_DEADLINE exec 200000000, deadline 200000000 period 200000000