### PR TITLE
Fix build with GNU libc 2.41

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,9 +17,9 @@ AC_CHECK_LIB([m], [round])
 AC_CHECK_LIB([rt], [clock_gettime])
 AC_CHECK_LIB([numa], [numa_available])
 AC_CHECK_LIB([json-c], [json_object_from_file], [], [AC_MSG_ERROR([json-c libraries required])])
-AC_CHECK_FUNCS(sched_setattr, [], [])
+AC_CHECK_FUNCS(sched_setattr, [have_sched_settattr=yes], [have_sched_settattr=no])
 
-AM_CONDITIONAL([SET_DLSCHED], [test !HAVE_SCHED_SETATTR])
+AM_CONDITIONAL([SET_DLSCHED], [test "x$have_sched_settattr" = xno])
 
 AC_ARG_VAR([LOGLVL], [verbosity level, from 0 to 100. 100 is very verbose])
 

--- a/src/rt-app_args.c
+++ b/src/rt-app_args.c
@@ -19,6 +19,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
+#define _GNU_SOURCE
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <string.h>
 #include <stdbool.h>
 #include <fcntl.h>
+#include <unistd.h>
 #include <json-c/json.h>
 
 #include "rt-app_utils.h"

--- a/src/rt-app_types.h
+++ b/src/rt-app_types.h
@@ -29,7 +29,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <pthread.h>
 #include <limits.h>
 #include "config.h"
+
+#ifndef HAVE_SCHED_SETATTR
 #include "dl_syscalls.h"
+#endif
 
 #if HAVE_LIBNUMA
 #include <numa.h>

--- a/src/rt-app_utils.c
+++ b/src/rt-app_utils.c
@@ -19,12 +19,15 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
+#define _GNU_SOURCE
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
 #include <math.h>
 #include <stdarg.h>
+#include <unistd.h>
+#include <sys/syscall.h>
 
 #include "rt-app_utils.h"
 


### PR DESCRIPTION
Starting with GNU libc 2.41, the sched_getattr and sched_setattr functions, and the sched_attr structure are provided in sched.h. This causes a conflict with the definition in libdl.

The configure script already checks for the sched_setattr function, but then the logic to compile and link libdl was wrong, as it is not possible to directly check the HAVE_SCHED_SETATTR with AM_CONDITIONAL. In addition the dl_syscalls.h include file needs to be guarded, and a few include files that were indirectly included by this file not to be done explictly.