### PR TITLE
Fix build on Fedora 42

### DIFF
--- a/src/rt-app_taskgroups.c
+++ b/src/rt-app_taskgroups.c
@@ -5,6 +5,7 @@
 #include <sys/types.h>
 #include <stdio.h>
 #include <errno.h>
+#include <unistd.h>
 
 #include "config.h"
 #include "rt-app_utils.h"

--- a/src/rt-app_types.h
+++ b/src/rt-app_types.h
@@ -25,6 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 /* For cpu_set_t type */
 #define _GNU_SOURCE
 #include <sched.h>
+#include <linux/sched.h>
 
 #include <pthread.h>
 #include <limits.h>


### PR DESCRIPTION
The build on Fedora 42 fails with two errors, I'm not sure if the
problem is in the combination of the shipped glibc-2.41 and gcc-15.1.1
(https://github.com/scheduler-tools/rt-app/pull/136 is not enough).

`SCHED_DEADLINE` is not defined if `<linux/sched.h>` is not included and
`rt-app_taskgroups.c` requires `<unistd.h>` which is not defined with
`HAVE_SCHED_SETATTR`.
