### PR TITLE
rt-app: Add memrun event with read, write, and chase workload types

### DIFF
--- a/doc/tutorial.txt
+++ b/doc/tutorial.txt
@@ -374,6 +374,27 @@ defined by "mem_buffer_size" in "global" object.
 in byte to be write into the IO device specified by "io_device" in "global"
 object.
 
+* memrun : Object. Memory access workloads with finer control than "mem".
+The "type" field selects one of "read", "write", or "chase". All variants
+take a "size" field (per-event buffer allocation in bytes, independent of
+the global "mem_buffer_size") and a "count" field whose meaning depends
+on the type.
+
+memrun "read" and "write" do sequential byte-at-a-time access of "count"
+bytes from the buffer, wrapping to offset 0 if count > size.
+
+memrun "chase" does pointer-chasing through a circular linked list of
+pointers placed every "stride" bytes in the buffer. "count" is the
+number of pointer dereferences (one chain hop each). The chain layout is
+controlled by:
+
+  - "stride" : Integer. Bytes between adjacent chain positions. Default 64.
+  - "pattern" : String. Either "random" (default), which uses bit-reversed
+    pointer ordering to defeat hardware prefetchers, or "sequential",
+    which orders the chain by linear stride.
+
+The legacy "mem" event is unchanged for backward compatibility.
+
 * timer : Object. Emulate the wake up of the thread by a timer. Timer differs
 from sleep event by the start time of the timer duration. Sleep duration starts
 at the beginning of the sleep event whereas timer duration starts at the end of

--- a/doc/tutorial.txt
+++ b/doc/tutorial.txt
@@ -594,6 +594,21 @@ with resume. String is ignored.
 taskA ...|run 5|suspend |----------------|run 5|suspend |----------------
 taskB ...-------------------|resume taskA|run 10    |--------------------
 
+* sem_post : String. Increment the POSIX semaphore named by the string.
+Never blocks. If a thread is blocked in sem_wait on the same semaphore,
+one is woken; otherwise the count increments and the post is remembered
+for a later sem_wait. Initial count is 0.
+
+* sem_wait : String. Decrement the POSIX semaphore named by the string,
+or block until count > 0. Unlike suspend/resume and signal/wait, the
+sem_post/sem_wait pair has memory: posts that arrive before any waiter
+is blocked accumulate, so a later wait consumes the count without
+blocking. This is the right primitive when an upstream thread may run
+ahead of the downstream waiter, e.g. pipeline patterns where the poster
+can complete several iterations before a preempted consumer gets to run.
+Both sem_post and sem_wait events using the same name reference the same
+underlying semaphore.
+
 * yield: String. Calls pthread_yield(), freeing the CPU for other tasks. This has a
 special meaning for SCHED_DEADLINE tasks. String can be empty.
 

--- a/doc/tutorial.txt
+++ b/doc/tutorial.txt
@@ -395,6 +395,55 @@ controlled by:
 
 The legacy "mem" event is unchanged for backward compatibility.
 
+Optional "ref" field for cross-thread sharing: similar to the "unique"
+pattern for timer (but inverted), memrun events default to per-thread
+isolated buffers. Adding "ref" : "<name>" to a memrun event opts into
+sharing: the resource lookup uses the user-provided name verbatim, so
+multiple tasks (and their threads) using the same name share one
+underlying buffer.
+
+Sharing decouples the aggregate working set from the thread count,
+which is useful in two main cases:
+
+  - Pinning the working set to a target cache level. If you want N
+    threads to all hit (say) L3, the working set must fit in L3.
+    With per-thread buffers of size B, the aggregate is N*B and easily
+    exceeds L3, producing misses instead of hits. A single shared
+    buffer of size <= L3 keeps the working set bounded regardless of N,
+    so all threads hit L3 after warmup.
+
+  - Avoiding OOM with large per-thread buffers. Many threads each
+    wanting a 32 MB chase buffer to generate cache misses (e.g. 100
+    threads * 32 MB = 3.2 GB) OOMs typical devices. One shared 32 MB
+    buffer still exceeds cache for the aggregate working set, so
+    cache-miss behavior is preserved while memory cost stays constant.
+
+Two memrun events using the same "ref" must agree on size/stride/pattern;
+otherwise rt-app exits with EXIT_INV_CONFIG at parse time.
+
+    "tasks" : {
+        "thread_a" : {
+            "phases" : {
+                "p" : {
+                    "memrun_a" : { "type" : "chase", "size" : 33554432,
+                                   "stride" : 64, "pattern" : "random",
+                                   "count" : 1000,
+                                   "ref" : "shared_chase_r_64_33554432" }
+                }
+            }
+        },
+        "thread_b" : {
+            "phases" : {
+                "p" : {
+                    "memrun_b" : { "type" : "chase", "size" : 33554432,
+                                   "stride" : 64, "pattern" : "random",
+                                   "count" : 1000,
+                                   "ref" : "shared_chase_r_64_33554432" }
+                }
+            }
+        }
+    }
+
 * timer : Object. Emulate the wake up of the thread by a timer. Timer differs
 from sleep event by the start time of the timer duration. Sleep duration starts
 at the beginning of the sleep event whereas timer duration starts at the end of

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -704,6 +704,18 @@ static int run_event(event_data_t *event, int dry_run,
 			pthread_mutex_unlock(&fork_mutex);
 		}
 		break;
+	case rtapp_sem_post:
+		{
+			log_debug("sem_post %s", rdata->name);
+			sem_post(&rdata->res.sem.obj);
+		}
+		break;
+	case rtapp_sem_wait:
+		{
+			log_debug("sem_wait %s", rdata->name);
+			sem_wait(&rdata->res.sem.obj);
+		}
+		break;
 	default:
 		break;
 	}

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -409,6 +409,58 @@ static void memload(unsigned long count, struct _rtapp_iomem_buf *iomem)
 	}
 }
 
+static void memread(unsigned long count, struct _rtapp_iomem_buf *iomem)
+{
+	volatile char *p = (volatile char *)iomem->ptr;
+	unsigned long buf_size = iomem->size;
+	unsigned long passes = count / buf_size;
+	unsigned long remainder = count % buf_size;
+	unsigned long i, j;
+
+	/*
+	 * p is volatile, so each access is a side effect that the compiler
+	 * must emit even when the value is discarded. No accumulator or ALU
+	 * op needed to keep the loads alive.
+	 */
+	for (i = 0; i < passes; i++)
+		for (j = 0; j < buf_size; j++)
+			(void)p[j];
+
+	for (j = 0; j < remainder; j++)
+		(void)p[j];
+}
+
+static void memwrite(unsigned long count, struct _rtapp_iomem_buf *iomem)
+{
+	volatile char *p = (volatile char *)iomem->ptr;
+	unsigned long buf_size = iomem->size;
+	unsigned long passes = count / buf_size;
+	unsigned long remainder = count % buf_size;
+	unsigned long i, j;
+
+	for (i = 0; i < passes; i++)
+		for (j = 0; j < buf_size; j++)
+			p[j] = (char)j;
+
+	for (j = 0; j < remainder; j++)
+		p[j] = (char)j;
+}
+
+static void memchase_run(unsigned long count, struct _rtapp_mem_chase_buf *chase)
+{
+	char **p = (char **)chase->base;
+	unsigned long i;
+
+	if (!p)
+		return;
+
+	for (i = 0; i < count; i++)
+		p = (char **)*p;
+
+	/* Prevent compiler from optimizing away the chases */
+	*(volatile char **)&chase->base = (char *)p;
+}
+
 static int run_event(event_data_t *event, int dry_run,
 		unsigned long *perf, thread_data_t *tdata,
 		struct timespec *t_first, log_data_t *ldata)
@@ -566,6 +618,24 @@ static int run_event(event_data_t *event, int dry_run,
 		{
 			log_debug("mem %d", event->count);
 			memload(event->count, &rdata->res.buf);
+		}
+		break;
+	case rtapp_mem_write:
+		{
+			log_debug("mem_write %d", event->count);
+			memwrite(event->count, &rdata->res.buf);
+		}
+		break;
+	case rtapp_mem_read:
+		{
+			log_debug("mem_read %d", event->count);
+			memread(event->count, &rdata->res.buf);
+		}
+		break;
+	case rtapp_mem_chase:
+		{
+			log_debug("mem_chase %d", event->count);
+			memchase_run(event->count, &rdata->res.chase);
 		}
 		break;
 	case rtapp_iorun:

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -767,6 +767,18 @@ static int run_event(event_data_t *event, int dry_run,
 			pthread_mutex_unlock(&fork_mutex);
 		}
 		break;
+	case rtapp_sem_post:
+		{
+			log_debug("sem_post %s", rdata->name);
+			sem_post(&rdata->res.sem.obj);
+		}
+		break;
+	case rtapp_sem_wait:
+		{
+			log_debug("sem_wait %s", rdata->name);
+			sem_wait(&rdata->res.sem.obj);
+		}
+		break;
 	default:
 		break;
 	}

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -409,6 +409,121 @@ static void memload(unsigned long count, struct _rtapp_iomem_buf *iomem)
 	}
 }
 
+static void memread(unsigned long count, struct _rtapp_iomem_buf *iomem)
+{
+	volatile char *p = (volatile char *)iomem->ptr;
+	unsigned long buf_size = iomem->size;
+	unsigned long passes = count / buf_size;
+	unsigned long remainder = count % buf_size;
+	unsigned long i, j;
+	char sink = 0;
+
+	for (i = 0; i < passes; i++)
+		for (j = 0; j < buf_size; j++)
+			sink += p[j];
+
+	for (j = 0; j < remainder; j++)
+		sink += p[j];
+
+	/* Prevent compiler from optimizing away the reads */
+	(void)sink;
+}
+
+static void memwrite(unsigned long count, struct _rtapp_iomem_buf *iomem)
+{
+	volatile char *p = (volatile char *)iomem->ptr;
+	unsigned long buf_size = iomem->size;
+	unsigned long passes = count / buf_size;
+	unsigned long remainder = count % buf_size;
+	unsigned long i, j;
+
+	for (i = 0; i < passes; i++)
+		for (j = 0; j < buf_size; j++)
+			p[j] = (char)j;
+
+	for (j = 0; j < remainder; j++)
+		p[j] = (char)j;
+}
+
+/*
+ * Bit-reverse an integer across nbits.
+ * E.g., bitreverse(1, 3) = 4 (001 -> 100)
+ */
+static inline unsigned int bitreverse(unsigned int val, int nbits)
+{
+	unsigned int result = 0;
+	int j;
+
+	for (j = 0; j < nbits; j++)
+		if (val & (1u << j))
+			result |= (1u << (nbits - j - 1));
+
+	return result;
+}
+
+/*
+ * Initialize a pointer chain for memory chase workload.
+ * Places one pointer per stride position in the buffer.
+ * random=1: bit-reversed order to defeat hardware prefetchers.
+ * random=0: sequential stride.
+ */
+static void memchase_init(struct _rtapp_mem_chase_buf *chase)
+{
+	size_t stride = chase->stride;
+	size_t npos = chase->size / stride;
+	int nbits;
+	size_t i;
+	char *base;
+
+	/* Round down to power of 2 for bit-reversal */
+	for (nbits = 0; (1u << (nbits + 1)) <= npos; nbits++)
+		;
+	npos = 1u << nbits;
+
+	if (npos < 2) {
+		log_error("mem_chase buffer too small (need at least 2 * stride)");
+		chase->base = NULL;
+		return;
+	}
+
+	base = malloc(npos * stride);
+	if (!base) {
+		log_error("Failed to allocate mem_chase buffer (%zu bytes)", npos * stride);
+		chase->base = NULL;
+		return;
+	}
+	chase->base = base;
+
+	if (chase->random) {
+		/* Bit-reversed pointer chain */
+		for (i = 0; i < npos; i++) {
+			size_t src_off = (size_t)bitreverse(i, nbits) * stride;
+			size_t dst_off = (size_t)bitreverse((i + 1) % npos, nbits) * stride;
+			*(char **)(base + src_off) = base + dst_off;
+		}
+	} else {
+		/* Sequential pointer chain */
+		for (i = 0; i < npos - 1; i++)
+			*(char **)(base + i * stride) = base + (i + 1) * stride;
+		*(char **)(base + (npos - 1) * stride) = base;
+	}
+}
+
+static void memchase_run(unsigned long count, struct _rtapp_mem_chase_buf *chase)
+{
+	char **p = (char **)chase->base;
+	unsigned long i;
+
+	if (!p)
+		return;
+
+	for (i = 0; i < count; i++)
+		p = (char **)*p;
+
+	/* Prevent compiler from optimizing away the chases */
+	*(volatile char **)&chase->base = (char *)p;
+}
+
 static int run_event(event_data_t *event, int dry_run,
 		unsigned long *perf, thread_data_t *tdata,
 		struct timespec *t_first, log_data_t *ldata)
@@ -566,6 +681,24 @@ static int run_event(event_data_t *event, int dry_run,
 		{
 			log_debug("mem %d", event->count);
 			memload(event->count, &rdata->res.buf);
+		}
+		break;
+	case rtapp_mem_write:
+		{
+			log_debug("mem_write %d", event->count);
+			memwrite(event->count, &rdata->res.buf);
+		}
+		break;
+	case rtapp_mem_read:
+		{
+			log_debug("mem_read %d", event->count);
+			memread(event->count, &rdata->res.buf);
+		}
+		break;
+	case rtapp_mem_chase:
+		{
+			log_debug("mem_chase %d", event->count);
+			memchase_run(event->count, &rdata->res.chase);
 		}
 		break;
 	case rtapp_iorun:
@@ -1614,6 +1747,13 @@ int main(int argc, char* argv[])
 
 	initialize_cgroups();
 	add_cgroups();
+
+	/* Initialize mem_chase pointer chains for all resources */
+	for (i = 0; i < opts.resources->nresources; i++) {
+		rtapp_resource_t *res = &opts.resources->resources[i];
+		if (res->type == rtapp_mem_chase && res->res.chase.base == NULL)
+			memchase_init(&res->res.chase);
+	}
 
 	/* Take the beginning time for everything */
 	clock_gettime(CLOCK_MONOTONIC, &t_start);

--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -230,6 +230,105 @@ static void init_membuf_resource(rtapp_resource_t *data, const rtapp_options_t *
 	data->res.buf.size = opts->mem_buffer_size;
 }
 
+/*
+ * Per-type init parameters threaded through get_resource_index ->
+ * add_resource_data -> init_resource_data so all per-type init lives
+ * in init_resource_data's switch. Caller fills in only the relevant
+ * member based on the resource type. May be NULL for param-free types
+ * (mutex, timer, wait, barrier, sem, iorun, legacy mem).
+ */
+union init_args {
+	struct {
+		int size;
+		int stride;
+		int random;
+	} chase;
+	struct {
+		int size;
+	} membuf;
+};
+
+static void init_membuf_resource_sized(rtapp_resource_t *data, int size)
+{
+	log_info(PIN3 "Init: %s membuf (size %d)", data->name, size);
+
+	data->res.buf.ptr = malloc(size);
+	data->res.buf.size = size;
+	if (data->res.buf.ptr)
+		memset(data->res.buf.ptr, 0xAA, size);
+}
+
+/*
+ * Bit-reverse an integer across nbits.
+ * E.g., bitreverse(1, 3) = 4 (001 -> 100)
+ */
+static inline unsigned int bitreverse(unsigned int val, int nbits)
+{
+	unsigned int result = 0;
+	int j;
+
+	for (j = 0; j < nbits; j++)
+		if (val & (1u << j))
+			result |= (1u << (nbits - j - 1));
+
+	return result;
+}
+
+/*
+ * Allocate the chase buffer and build its pointer chain.
+ *
+ * random=1: bit-reversed order to defeat hardware prefetchers.
+ * random=0: sequential stride.
+ */
+static void init_memchase_resource(rtapp_resource_t *data, int size, int stride, int random)
+{
+	struct _rtapp_mem_chase_buf *chase = &data->res.chase;
+	size_t npos;
+	int nbits;
+	size_t i;
+	char *base;
+
+	log_info(PIN3 "Init: %s mem_chase (size %d, stride %d, %s)", data->name,
+		 size, stride, random ? "random" : "sequential");
+
+	chase->size = size;
+	chase->stride = stride;
+	chase->random = random;
+
+	npos = (size_t)size / (size_t)stride;
+	/* Round down to power of 2 for bit-reversal */
+	for (nbits = 0; (1u << (nbits + 1)) <= npos; nbits++)
+		;
+	npos = 1u << nbits;
+
+	if (npos < 2) {
+		log_error("mem_chase buffer too small (need at least 2 * stride)");
+		return;
+	}
+
+	base = malloc(npos * (size_t)stride);
+	if (!base) {
+		log_error("Failed to allocate mem_chase buffer (%zu bytes)",
+			  npos * (size_t)stride);
+		return;
+	}
+	chase->base = base;
+
+	if (random) {
+		/* Bit-reversed pointer chain */
+		for (i = 0; i < npos; i++) {
+			size_t src_off = (size_t)bitreverse(i, nbits) * stride;
+			size_t dst_off = (size_t)bitreverse((i + 1) % npos, nbits) * stride;
+			*(char **)(base + src_off) = base + dst_off;
+		}
+	} else {
+		/* Sequential pointer chain */
+		for (i = 0; i < npos - 1; i++)
+			*(char **)(base + i * stride) = base + (i + 1) * stride;
+		*(char **)(base + (npos - 1) * stride) = base;
+	}
+}
+
 static void init_iodev_resource(rtapp_resource_t *data, const rtapp_options_t *opts)
 {
 	log_info(PIN3 "Init: %s io device", data->name);
@@ -260,7 +359,8 @@ static void init_barrier_resource(rtapp_resource_t *data, const rtapp_options_t 
 
 static void
 init_resource_data(const char *name, int type, rtapp_resources_t *resources_table,
-		int idx, const rtapp_options_t *opts)
+		int idx, const rtapp_options_t *opts,
+		const union init_args *args)
 {
 	rtapp_resource_t *data = &(resources_table->resources[idx]);
 
@@ -282,6 +382,15 @@ init_resource_data(const char *name, int type, rtapp_resources_t *resources_tabl
 			break;
 		case rtapp_mem:
 			init_membuf_resource(data, opts);
+			break;
+		case rtapp_mem_write:
+		case rtapp_mem_read:
+			init_membuf_resource_sized(data, args->membuf.size);
+			break;
+		case rtapp_mem_chase:
+			init_memchase_resource(data, args->chase.size,
+					       args->chase.stride,
+					       args->chase.random);
 			break;
 		case rtapp_iorun:
 			init_iodev_resource(data, opts);
@@ -317,11 +426,18 @@ parse_resource_data(const char *name, struct json_object *obj, int idx,
 	 */
 	free(type);
 
-	init_resource_data(name, data->type, opts->resources, idx, opts);
+	/*
+	 * The top-level "resources" block doesn't accept memrun types
+	 * (string_to_resource only knows mutex/wait/timer/etc.), so the
+	 * memrun cases in init_resource_data's switch are unreachable
+	 * via this path. NULL args is therefore safe.
+	 */
+	init_resource_data(name, data->type, opts->resources, idx, opts, NULL);
 }
 
 static int
-add_resource_data(const char *name, int type, rtapp_resources_t **resources_table, rtapp_options_t *opts)
+add_resource_data(const char *name, int type, rtapp_resources_t **resources_table,
+		rtapp_options_t *opts, const union init_args *args)
 {
 	int idx, size;
 	rtapp_resources_t *table = *resources_table;
@@ -345,7 +461,7 @@ add_resource_data(const char *name, int type, rtapp_resources_t **resources_tabl
 	 * We can't reuse table as *resources_table might have changed following
 	 * realloc
 	 */
-	init_resource_data(name, type, *resources_table, idx, opts);
+	init_resource_data(name, type, *resources_table, idx, opts, args);
 
 	return idx;
 }
@@ -396,7 +512,9 @@ parse_resources(struct json_object *resources, rtapp_options_t *opts)
 	}
 }
 
-static int get_resource_index(const char *name, int type, rtapp_resources_t **resources_table, rtapp_options_t *opts)
+static int get_resource_index(const char *name, int type,
+		const union init_args *args,
+		rtapp_resources_t **resources_table, rtapp_options_t *opts)
 {
 	int nresources = (*resources_table)->nresources;
 	rtapp_resource_t *resources = (*resources_table)->resources;
@@ -407,7 +525,7 @@ static int get_resource_index(const char *name, int type, rtapp_resources_t **re
 		i++;
 
 	if (i >= nresources)
-		i = add_resource_data(name, type, resources_table, opts);
+		i = add_resource_data(name, type, resources_table, opts, args);
 
 	return i;
 }
@@ -424,7 +542,7 @@ parse_task_event_data(char *name, struct json_object *obj,
 {
 	rtapp_resources_t **resources_table = tdata->global_resources;
 	rtapp_resource_t *rdata, *ddata;
-	char unique_name[22];
+	char unique_name[64];
 	const char *ref;
 	char *tmp;
 	long tag = (long)tdata;
@@ -450,6 +568,67 @@ parse_task_event_data(char *name, struct json_object *obj,
 		return;
 	}
 
+	if (!strncmp(name, "memrun", strlen("memrun"))) {
+		if (!json_object_is_type(obj, json_type_object))
+			goto unknown_event;
+
+		char *mem_type = get_string_value_from(obj, "type", FALSE, NULL);
+		int mem_size = get_int_value_from(obj, "size", FALSE, 0);
+		int mem_count = get_int_value_from(obj, "count", FALSE, 0);
+
+		if (!strcmp(mem_type, "chase")) {
+			char *pattern = get_string_value_from(obj, "pattern", TRUE, "random");
+			int is_random = strcmp(pattern, "sequential") != 0;
+			int stride = get_int_value_from(obj, "stride", TRUE, 64);
+			char encoded[48];
+			union init_args ia = { .chase = { mem_size, stride, is_random } };
+
+			/*
+			 * Encode the chase params into the resource name so that
+			 * different (size, stride, pattern) combinations get
+			 * distinct buffers, while identical configs share one.
+			 */
+			snprintf(encoded, sizeof(encoded), "memrun_%c_%d_%d",
+			         is_random ? 'r' : 's', stride, mem_size);
+			ref = create_unique_name(unique_name, sizeof(unique_name), encoded, tag);
+
+			data->res = get_resource_index(ref, rtapp_mem_chase, &ia,
+			                               resources_table, opts);
+			data->count = mem_count;
+			data->type = rtapp_mem_chase;
+			free(pattern);
+		} else if (!strcmp(mem_type, "read")) {
+			char encoded[48];
+			union init_args ia = { .membuf = { mem_size } };
+
+			snprintf(encoded, sizeof(encoded), "memrun_read_%d", mem_size);
+			ref = create_unique_name(unique_name, sizeof(unique_name), encoded, tag);
+			data->res = get_resource_index(ref, rtapp_mem_read, &ia,
+			                               resources_table, opts);
+			data->count = mem_count;
+			data->type = rtapp_mem_read;
+		} else if (!strcmp(mem_type, "write")) {
+			char encoded[48];
+			union init_args ia = { .membuf = { mem_size } };
+
+			snprintf(encoded, sizeof(encoded), "memrun_write_%d", mem_size);
+			ref = create_unique_name(unique_name, sizeof(unique_name), encoded, tag);
+			data->res = get_resource_index(ref, rtapp_mem_write, &ia,
+			                               resources_table, opts);
+			data->count = mem_count;
+			data->type = rtapp_mem_write;
+		} else {
+			log_critical(PIN2 "Unknown memrun type: %s", mem_type);
+			free(mem_type);
+			goto unknown_event;
+		}
+
+		free(mem_type);
+		log_info(PIN2 "type %d count %d", data->type, data->count);
+		strncpy(data->name, unique_name, sizeof(data->name)-1);
+		return;
+	}
+
 	if (!strncmp(name, "mem", strlen("mem")) ||
 			!strncmp(name, "iorun", strlen("iorun"))) {
 		if (!json_object_is_type(obj, json_type_int))
@@ -457,13 +636,13 @@ parse_task_event_data(char *name, struct json_object *obj,
 
 		/* create an unique name for per-thread buffer */
 		ref = create_unique_name(unique_name, sizeof(unique_name), "mem", tag);
-		i = get_resource_index(ref, rtapp_mem, resources_table, opts);
+		i = get_resource_index(ref, rtapp_mem, NULL, resources_table, opts);
 		data->res = i;
 		data->count = json_object_get_int(obj);
 
 		/* A single IO devices for all threads */
 		if (strncmp(name, "iorun", strlen("iorun")) == 0) {
-			i = get_resource_index("io_device", rtapp_iorun, resources_table, opts);
+			i = get_resource_index("io_device", rtapp_iorun, NULL, resources_table, opts);
 			data->dep = i;
 		};
 
@@ -484,7 +663,7 @@ parse_task_event_data(char *name, struct json_object *obj,
 			goto unknown_event;
 
 		ref = json_object_get_string(obj);
-		i = get_resource_index(ref, rtapp_mutex, resources_table, opts);
+		i = get_resource_index(ref, rtapp_mutex, NULL, resources_table, opts);
 
 		data->res = i;
 
@@ -513,7 +692,7 @@ parse_task_event_data(char *name, struct json_object *obj,
 			goto unknown_event;
 
 		ref = json_object_get_string(obj);
-		i = get_resource_index(ref, rtapp_wait, resources_table, opts);
+		i = get_resource_index(ref, rtapp_wait, NULL, resources_table, opts);
 
 		data->res = i;
 
@@ -534,7 +713,7 @@ parse_task_event_data(char *name, struct json_object *obj,
 			data->type = rtapp_sig_and_wait;
 
 		tmp = get_string_value_from(obj, "ref", TRUE, "unknown");
-		i = get_resource_index(tmp, rtapp_wait, resources_table, opts);
+		i = get_resource_index(tmp, rtapp_wait, NULL, resources_table, opts);
 		/*
 		 * get_string_value_from allocate the string so with have to free it
 		 * once useless
@@ -544,7 +723,7 @@ parse_task_event_data(char *name, struct json_object *obj,
 		data->res = i;
 
 		tmp = get_string_value_from(obj, "mutex", TRUE, "unknown");
-		i = get_resource_index(tmp, rtapp_mutex, resources_table, opts);
+		i = get_resource_index(tmp, rtapp_mutex, NULL, resources_table, opts);
 		/*
 		 * get_string_value_from allocate the string so with have to free it
 		 * once useless
@@ -570,7 +749,7 @@ parse_task_event_data(char *name, struct json_object *obj,
 		data->type = rtapp_barrier;
 
 		ref = json_object_get_string(obj);
-		i = get_resource_index(ref, rtapp_barrier, resources_table, opts);
+		i = get_resource_index(ref, rtapp_barrier, NULL, resources_table, opts);
 
 		data->res = i;
 		rdata = &((*resources_table)->resources[data->res]);
@@ -595,7 +774,7 @@ parse_task_event_data(char *name, struct json_object *obj,
 			data->type = rtapp_timer;
 		}
 
-		data->res = get_resource_index(ref, data->type, resources_table, opts);
+		data->res = get_resource_index(ref, data->type, NULL, resources_table, opts);
 
 		/*
 		 * get_string_value_from allocate the string so with have to free it
@@ -627,11 +806,11 @@ parse_task_event_data(char *name, struct json_object *obj,
 
 		ref = json_object_get_string(obj);
 
-		i = get_resource_index(ref, rtapp_wait, resources_table, opts);
+		i = get_resource_index(ref, rtapp_wait, NULL, resources_table, opts);
 
 		data->res = i;
 
-		i = get_resource_index(ref, rtapp_mutex, resources_table, opts);
+		i = get_resource_index(ref, rtapp_mutex, NULL, resources_table, opts);
 
 		data->dep = i;
 
@@ -650,11 +829,11 @@ parse_task_event_data(char *name, struct json_object *obj,
 
 		ref = tdata->name;
 
-		i = get_resource_index(ref, rtapp_wait, resources_table, opts);
+		i = get_resource_index(ref, rtapp_wait, NULL, resources_table, opts);
 
 		data->res = i;
 
-		i = get_resource_index(ref, rtapp_mutex, resources_table, opts);
+		i = get_resource_index(ref, rtapp_mutex, NULL, resources_table, opts);
 
 		data->dep = i;
 
@@ -683,7 +862,7 @@ parse_task_event_data(char *name, struct json_object *obj,
 
 		ref = json_object_get_string(obj);
 
-		i = get_resource_index(ref, rtapp_fork, resources_table, opts);
+		i = get_resource_index(ref, rtapp_fork, NULL, resources_table, opts);
 
 		data->res = i;
 
@@ -725,6 +904,7 @@ static char *events[] = {
 	"timer",
 	"suspend",
 	"resume",
+	"memrun",
 	"mem",
 	"iorun",
 	"yield",

--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -357,6 +357,12 @@ static void init_barrier_resource(rtapp_resource_t *data, const rtapp_options_t 
 	pthread_cond_init(&data->res.barrier.c_obj, NULL);
 }
 
+static void init_sem_resource(rtapp_resource_t *data, const rtapp_options_t *opts)
+{
+	log_info(PIN3 "Init: %s semaphore", data->name);
+	sem_init(&data->res.sem.obj, 0, 0);
+}
+
 static void
 init_resource_data(const char *name, int type, rtapp_resources_t *resources_table,
 		int idx, const rtapp_options_t *opts,
@@ -397,6 +403,10 @@ init_resource_data(const char *name, int type, rtapp_resources_t *resources_tabl
 			break;
 		case rtapp_barrier:
 			init_barrier_resource(data, opts);
+			break;
+		case rtapp_sem_wait:
+		case rtapp_sem_post:
+			init_sem_resource(data, opts);
 			break;
 		default:
 			break;
@@ -883,6 +893,46 @@ parse_task_event_data(char *name, struct json_object *obj,
 		return;
 	}
 
+	if (!strncmp(name, "sem_post", strlen("sem_post"))) {
+
+		data->type = rtapp_sem_post;
+
+		if (!json_object_is_type(obj, json_type_string))
+			goto unknown_event;
+
+		ref = json_object_get_string(obj);
+		i = get_resource_index(ref, rtapp_sem_post, NULL, resources_table, opts);
+
+		data->res = i;
+
+		rdata = &((*resources_table)->resources[data->res]);
+
+		log_info(PIN2 "type %d target %s [%d]", data->type, rdata->name, rdata->index);
+		snprintf(data->name, sizeof(data->name)-1, "%s:%s",
+			 name, rdata->name);
+		return;
+	}
+
+	if (!strncmp(name, "sem_wait", strlen("sem_wait"))) {
+
+		data->type = rtapp_sem_wait;
+
+		if (!json_object_is_type(obj, json_type_string))
+			goto unknown_event;
+
+		ref = json_object_get_string(obj);
+		i = get_resource_index(ref, rtapp_sem_post, NULL, resources_table, opts);
+
+		data->res = i;
+
+		rdata = &((*resources_table)->resources[data->res]);
+
+		log_info(PIN2 "type %d target %s [%d]", data->type, rdata->name, rdata->index);
+		snprintf(data->name, sizeof(data->name)-1, "%s:%s",
+			 name, rdata->name);
+		return;
+	}
+
 	log_error(PIN2 "Resource %s not found in the resource section !!!", ref);
 	log_error(PIN2 "Please check the resource name or the resource section");
 
@@ -910,6 +960,8 @@ static char *events[] = {
 	"yield",
 	"barrier",
 	"fork",
+	"sem_post",
+	"sem_wait",
 	NULL
 };
 

--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -522,6 +522,32 @@ parse_resources(struct json_object *resources, rtapp_options_t *opts)
 	}
 }
 
+/*
+ * Verify that a previously-created resource was initialized with the
+ * same params the current caller is asking for. Mismatches happen when
+ * two memrun events share a name (typically via "ref") but disagree on
+ * size/stride/pattern. Returns 1 on match, 0 on mismatch. For
+ * param-free types, or when no args are passed, always matches.
+ */
+static int validate_init_args(const rtapp_resource_t *r,
+		const union init_args *args)
+{
+	if (!args)
+		return 1;
+
+	switch (r->type) {
+	case rtapp_mem_chase:
+		return r->res.chase.size == (size_t)args->chase.size &&
+		       r->res.chase.stride == (size_t)args->chase.stride &&
+		       r->res.chase.random == args->chase.random;
+	case rtapp_mem_read:
+	case rtapp_mem_write:
+		return r->res.buf.size == args->membuf.size;
+	default:
+		return 1;
+	}
+}
+
 static int get_resource_index(const char *name, int type,
 		const union init_args *args,
 		rtapp_resources_t **resources_table, rtapp_options_t *opts)
@@ -535,7 +561,20 @@ static int get_resource_index(const char *name, int type,
 		i++;
 
 	if (i >= nresources)
-		i = add_resource_data(name, type, resources_table, opts, args);
+		return add_resource_data(name, type, resources_table, opts, args);
+
+	/*
+	 * Existing resource: make sure the caller's params match. For
+	 * per-thread memrun the encoded resource name guarantees identical
+	 * params, so this is a defensive no-op. With user-provided "ref",
+	 * this catches accidental param mismatches across threads.
+	 */
+	if (!validate_init_args(&resources[i], args)) {
+		log_critical(PFX "Resource '%s' shared with mismatched params. "
+		             "Multiple memrun events using the same name (or "
+		             "\"ref\") must agree on size/stride/pattern.", name);
+		exit(EXIT_INV_CONFIG);
+	}
 
 	return i;
 }
@@ -585,6 +624,14 @@ parse_task_event_data(char *name, struct json_object *obj,
 		char *mem_type = get_string_value_from(obj, "type", FALSE, NULL);
 		int mem_size = get_int_value_from(obj, "size", FALSE, 0);
 		int mem_count = get_int_value_from(obj, "count", FALSE, 0);
+		/*
+		 * Optional "ref" field: when provided, the resource name is the
+		 * user's ref string verbatim: no per-thread tag, no params
+		 * encoding. Multiple threads (and tasks) using the same ref
+		 * share one underlying buffer. Without "ref", default per-thread
+		 * isolation via encoded params + tag.
+		 */
+		tmp = get_string_value_from(obj, "ref", TRUE, NULL);
 
 		if (!strcmp(mem_type, "chase")) {
 			char *pattern = get_string_value_from(obj, "pattern", TRUE, "random");
@@ -593,14 +640,19 @@ parse_task_event_data(char *name, struct json_object *obj,
 			char encoded[48];
 			union init_args ia = { .chase = { mem_size, stride, is_random } };
 
-			/*
-			 * Encode the chase params into the resource name so that
-			 * different (size, stride, pattern) combinations get
-			 * distinct buffers, while identical configs share one.
-			 */
-			snprintf(encoded, sizeof(encoded), "memrun_%c_%d_%d",
-			         is_random ? 'r' : 's', stride, mem_size);
-			ref = create_unique_name(unique_name, sizeof(unique_name), encoded, tag);
+			if (tmp) {
+				ref = tmp;
+			} else {
+				/*
+				 * Encode chase params into the resource name so distinct
+				 * (size, stride, pattern) combos get distinct buffers
+				 * within one task, while identical configs share one.
+				 */
+				snprintf(encoded, sizeof(encoded), "memrun_%c_%d_%d",
+				         is_random ? 'r' : 's', stride, mem_size);
+				ref = create_unique_name(unique_name, sizeof(unique_name),
+				                         encoded, tag);
+			}
 
 			data->res = get_resource_index(ref, rtapp_mem_chase, &ia,
 			                               resources_table, opts);
@@ -611,8 +663,13 @@ parse_task_event_data(char *name, struct json_object *obj,
 			char encoded[48];
 			union init_args ia = { .membuf = { mem_size } };
 
-			snprintf(encoded, sizeof(encoded), "memrun_read_%d", mem_size);
-			ref = create_unique_name(unique_name, sizeof(unique_name), encoded, tag);
+			if (tmp) {
+				ref = tmp;
+			} else {
+				snprintf(encoded, sizeof(encoded), "memrun_read_%d", mem_size);
+				ref = create_unique_name(unique_name, sizeof(unique_name),
+				                         encoded, tag);
+			}
 			data->res = get_resource_index(ref, rtapp_mem_read, &ia,
 			                               resources_table, opts);
 			data->count = mem_count;
@@ -621,21 +678,26 @@ parse_task_event_data(char *name, struct json_object *obj,
 			char encoded[48];
 			union init_args ia = { .membuf = { mem_size } };
 
-			snprintf(encoded, sizeof(encoded), "memrun_write_%d", mem_size);
-			ref = create_unique_name(unique_name, sizeof(unique_name), encoded, tag);
+			if (tmp) {
+				ref = tmp;
+			} else {
+				snprintf(encoded, sizeof(encoded), "memrun_write_%d", mem_size);
+				ref = create_unique_name(unique_name, sizeof(unique_name),
+				                         encoded, tag);
+			}
 			data->res = get_resource_index(ref, rtapp_mem_write, &ia,
 			                               resources_table, opts);
 			data->count = mem_count;
 			data->type = rtapp_mem_write;
 		} else {
 			log_critical(PIN2 "Unknown memrun type: %s", mem_type);
-			free(mem_type);
 			goto unknown_event;
 		}
 
 		free(mem_type);
 		log_info(PIN2 "type %d count %d", data->type, data->count);
-		strncpy(data->name, unique_name, sizeof(data->name)-1);
+		strncpy(data->name, ref, sizeof(data->name)-1);
+		free(tmp);
 		return;
 	}
 

--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -230,6 +230,28 @@ static void init_membuf_resource(rtapp_resource_t *data, const rtapp_options_t *
 	data->res.buf.size = opts->mem_buffer_size;
 }
 
+static void init_membuf_resource_sized(rtapp_resource_t *data, int size)
+{
+	log_info(PIN3 "Init: %s membuf (size %d)", data->name, size);
+
+	data->res.buf.ptr = malloc(size);
+	data->res.buf.size = size;
+	if (data->res.buf.ptr)
+		memset(data->res.buf.ptr, 0xAA, size);
+}
+
+static void init_memchase_resource(rtapp_resource_t *data, int size, int stride, int random)
+{
+	log_info(PIN3 "Init: %s mem_chase (size %d, stride %d, %s)", data->name,
+		 size, stride, random ? "random" : "sequential");
+
+	data->res.chase.size = size;
+	data->res.chase.stride = stride;
+	data->res.chase.random = random;
+	data->res.chase.base = NULL;
+	/* Chain is initialized by memchase_init() called from rt-app.c */
+}
+
 static void init_iodev_resource(rtapp_resource_t *data, const rtapp_options_t *opts)
 {
 	log_info(PIN3 "Init: %s io device", data->name);
@@ -281,7 +303,12 @@ init_resource_data(const char *name, int type, rtapp_resources_t *resources_tabl
 			init_cond_resource(data, opts);
 			break;
 		case rtapp_mem:
+		case rtapp_mem_write:
+		case rtapp_mem_read:
 			init_membuf_resource(data, opts);
+			break;
+		case rtapp_mem_chase:
+			/* Initialized later with size/pattern from JSON */
 			break;
 		case rtapp_iorun:
 			init_iodev_resource(data, opts);
@@ -424,7 +451,7 @@ parse_task_event_data(char *name, struct json_object *obj,
 {
 	rtapp_resources_t **resources_table = tdata->global_resources;
 	rtapp_resource_t *rdata, *ddata;
-	char unique_name[22];
+	char unique_name[RTAPP_EVENT_NAME_LENGTH + sizeof(long) * 2 + 1];
 	const char *ref;
 	char *tmp;
 	long tag = (long)tdata;
@@ -447,6 +474,60 @@ parse_task_event_data(char *name, struct json_object *obj,
 
 		log_info(PIN2 "type %d duration %d", data->type, data->duration);
 		strncpy(data->name, name, sizeof(data->name)-1);
+		return;
+	}
+
+	if (!strncmp(name, "memrun", strlen("memrun"))) {
+		if (!json_object_is_type(obj, json_type_object))
+			goto unknown_event;
+
+		ref = create_unique_name(unique_name, sizeof(unique_name), name, tag);
+
+		char *mem_type = get_string_value_from(obj, "type", FALSE, NULL);
+		int mem_size = get_int_value_from(obj, "size", FALSE, 0);
+		int mem_count = get_int_value_from(obj, "count", FALSE, 0);
+
+		if (!strcmp(mem_type, "chase")) {
+			char *pattern = get_string_value_from(obj, "pattern", TRUE, "random");
+			int is_random = strcmp(pattern, "sequential") != 0;
+			int stride = get_int_value_from(obj, "stride", TRUE, 64);
+
+			i = get_resource_index(ref, rtapp_mem_chase, resources_table, opts);
+			data->res = i;
+
+			rtapp_resource_t *mdata = &((*resources_table)->resources[i]);
+			init_memchase_resource(mdata, mem_size, stride, is_random);
+
+			data->count = mem_count;
+			data->type = rtapp_mem_chase;
+			free(pattern);
+		} else if (!strcmp(mem_type, "read")) {
+			i = get_resource_index(ref, rtapp_mem_read, resources_table, opts);
+			data->res = i;
+
+			rtapp_resource_t *mdata = &((*resources_table)->resources[i]);
+			init_membuf_resource_sized(mdata, mem_size);
+
+			data->count = mem_count;
+			data->type = rtapp_mem_read;
+		} else if (!strcmp(mem_type, "write")) {
+			i = get_resource_index(ref, rtapp_mem_write, resources_table, opts);
+			data->res = i;
+
+			rtapp_resource_t *mdata = &((*resources_table)->resources[i]);
+			init_membuf_resource_sized(mdata, mem_size);
+
+			data->count = mem_count;
+			data->type = rtapp_mem_write;
+		} else {
+			log_critical(PIN2 "Unknown memrun type: %s", mem_type);
+			free(mem_type);
+			goto unknown_event;
+		}
+
+		free(mem_type);
+		log_info(PIN2 "type %d count %d", data->type, data->count);
+		strncpy(data->name, unique_name, sizeof(data->name)-1);
 		return;
 	}
 
@@ -725,6 +806,7 @@ static char *events[] = {
 	"timer",
 	"suspend",
 	"resume",
+	"memrun",
 	"mem",
 	"iorun",
 	"yield",

--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -280,6 +280,12 @@ static void init_barrier_resource(rtapp_resource_t *data, const rtapp_options_t 
 	pthread_cond_init(&data->res.barrier.c_obj, NULL);
 }
 
+static void init_sem_resource(rtapp_resource_t *data, const rtapp_options_t *opts)
+{
+	log_info(PIN3 "Init: %s semaphore", data->name);
+	sem_init(&data->res.sem.obj, 0, 0);
+}
+
 static void
 init_resource_data(const char *name, int type, rtapp_resources_t *resources_table,
 		int idx, const rtapp_options_t *opts)
@@ -315,6 +321,10 @@ init_resource_data(const char *name, int type, rtapp_resources_t *resources_tabl
 			break;
 		case rtapp_barrier:
 			init_barrier_resource(data, opts);
+			break;
+		case rtapp_sem_wait:
+		case rtapp_sem_post:
+			init_sem_resource(data, opts);
 			break;
 		default:
 			break;
@@ -785,6 +795,46 @@ parse_task_event_data(char *name, struct json_object *obj,
 		return;
 	}
 
+	if (!strncmp(name, "sem_post", strlen("sem_post"))) {
+
+		data->type = rtapp_sem_post;
+
+		if (!json_object_is_type(obj, json_type_string))
+			goto unknown_event;
+
+		ref = json_object_get_string(obj);
+		i = get_resource_index(ref, rtapp_sem_post, resources_table, opts);
+
+		data->res = i;
+
+		rdata = &((*resources_table)->resources[data->res]);
+
+		log_info(PIN2 "type %d target %s [%d]", data->type, rdata->name, rdata->index);
+		snprintf(data->name, sizeof(data->name)-1, "%s:%s",
+			 name, rdata->name);
+		return;
+	}
+
+	if (!strncmp(name, "sem_wait", strlen("sem_wait"))) {
+
+		data->type = rtapp_sem_wait;
+
+		if (!json_object_is_type(obj, json_type_string))
+			goto unknown_event;
+
+		ref = json_object_get_string(obj);
+		i = get_resource_index(ref, rtapp_sem_post, resources_table, opts);
+
+		data->res = i;
+
+		rdata = &((*resources_table)->resources[data->res]);
+
+		log_info(PIN2 "type %d target %s [%d]", data->type, rdata->name, rdata->index);
+		snprintf(data->name, sizeof(data->name)-1, "%s:%s",
+			 name, rdata->name);
+		return;
+	}
+
 	log_error(PIN2 "Resource %s not found in the resource section !!!", ref);
 	log_error(PIN2 "Please check the resource name or the resource section");
 
@@ -812,6 +862,8 @@ static char *events[] = {
 	"yield",
 	"barrier",
 	"fork",
+	"sem_post",
+	"sem_wait",
 	NULL
 };
 

--- a/src/rt-app_types.h
+++ b/src/rt-app_types.h
@@ -91,6 +91,9 @@ typedef enum resource_t
 	rtapp_suspend,
 	rtapp_resume,
 	rtapp_mem,
+	rtapp_mem_write,
+	rtapp_mem_read,
+	rtapp_mem_chase,
 	rtapp_iorun,
 	rtapp_runtime,
 	rtapp_yield,
@@ -137,6 +140,13 @@ struct _rtapp_iomem_buf {
 	int size;
 };
 
+struct _rtapp_mem_chase_buf {
+	char *base;		/* aligned buffer */
+	size_t size;		/* buffer size in bytes */
+	size_t stride;		/* bytes between pointer positions */
+	int random;		/* 1 = bit-reversed, 0 = sequential */
+};
+
 struct _rtapp_iodev {
 	int fd;
 };
@@ -155,6 +165,7 @@ typedef struct _rtapp_resource_t {
 		struct _rtapp_signal signal;
 		struct _rtapp_timer timer;
 		struct _rtapp_iomem_buf buf;
+		struct _rtapp_mem_chase_buf chase;
 		struct _rtapp_iodev dev;
 		struct _rtapp_barrier_like barrier;
 		struct _rtapp_fork fork;

--- a/src/rt-app_types.h
+++ b/src/rt-app_types.h
@@ -28,6 +28,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <linux/sched.h>
 
 #include <pthread.h>
+#include <semaphore.h>
 #include <limits.h>
 #include "config.h"
 
@@ -98,7 +99,9 @@ typedef enum resource_t
 	rtapp_runtime,
 	rtapp_yield,
 	rtapp_barrier,
-	rtapp_fork
+	rtapp_fork,
+	rtapp_sem_wait,
+	rtapp_sem_post
 } resource_t;
 
 struct _rtapp_mutex {
@@ -157,6 +160,10 @@ struct _rtapp_fork {
 	int nforks;
 };
 
+struct _rtapp_sem {
+	sem_t obj;
+};
+
 /* Shared resources */
 typedef struct _rtapp_resource_t {
 	union {
@@ -169,6 +176,7 @@ typedef struct _rtapp_resource_t {
 		struct _rtapp_iodev dev;
 		struct _rtapp_barrier_like barrier;
 		struct _rtapp_fork fork;
+		struct _rtapp_sem sem;
 	} res;
 	int index;
 	resource_t type;

--- a/src/rt-app_types.h
+++ b/src/rt-app_types.h
@@ -41,6 +41,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 #define RTAPP_POLICY_DESCR_LENGTH 16
 #define RTAPP_RESOURCE_DESCR_LENGTH 16
+#define RTAPP_EVENT_NAME_LENGTH 48
 #define RTAPP_FTRACE_PATH_LENGTH 256
 
 #define DEFAULT_THREAD_PRIORITY 10
@@ -91,6 +92,9 @@ typedef enum resource_t
 	rtapp_suspend,
 	rtapp_resume,
 	rtapp_mem,
+	rtapp_mem_write,
+	rtapp_mem_read,
+	rtapp_mem_chase,
 	rtapp_iorun,
 	rtapp_runtime,
 	rtapp_yield,
@@ -137,6 +141,13 @@ struct _rtapp_iomem_buf {
 	int size;
 };
 
+struct _rtapp_mem_chase_buf {
+	char *base;		/* aligned buffer */
+	size_t size;		/* buffer size in bytes */
+	size_t stride;		/* bytes between pointer positions */
+	int random;		/* 1 = bit-reversed, 0 = sequential */
+};
+
 struct _rtapp_iodev {
 	int fd;
 };
@@ -155,6 +166,7 @@ typedef struct _rtapp_resource_t {
 		struct _rtapp_signal signal;
 		struct _rtapp_timer timer;
 		struct _rtapp_iomem_buf buf;
+		struct _rtapp_mem_chase_buf chase;
 		struct _rtapp_iodev dev;
 		struct _rtapp_barrier_like barrier;
 		struct _rtapp_fork fork;
@@ -170,7 +182,7 @@ typedef struct _rtapp_resources_t {
 } rtapp_resources_t;
 
 typedef struct _event_data_t {
-	char name[48];
+	char name[RTAPP_EVENT_NAME_LENGTH];
 	resource_t type;
 	int res;
 	int dep;

--- a/src/rt-app_types.h
+++ b/src/rt-app_types.h
@@ -28,6 +28,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <linux/sched.h>
 
 #include <pthread.h>
+#include <semaphore.h>
 #include <limits.h>
 #include "config.h"
 
@@ -99,7 +100,9 @@ typedef enum resource_t
 	rtapp_runtime,
 	rtapp_yield,
 	rtapp_barrier,
-	rtapp_fork
+	rtapp_fork,
+	rtapp_sem_wait,
+	rtapp_sem_post
 } resource_t;
 
 struct _rtapp_mutex {
@@ -158,6 +161,10 @@ struct _rtapp_fork {
 	int nforks;
 };
 
+struct _rtapp_sem {
+	sem_t obj;
+};
+
 /* Shared resources */
 typedef struct _rtapp_resource_t {
 	union {
@@ -170,6 +177,7 @@ typedef struct _rtapp_resource_t {
 		struct _rtapp_iodev dev;
 		struct _rtapp_barrier_like barrier;
 		struct _rtapp_fork fork;
+		struct _rtapp_sem sem;
 	} res;
 	int index;
 	resource_t type;


### PR DESCRIPTION
Add a new "memrun" event that supports three memory workload types beyond the existing "mem" (memset) and "iorun" (write syscall):

  - "write": byte-at-a-time volatile stores over a sized buffer
  - "read": byte-at-a-time volatile reads over a sized buffer
  - "chase": pointer-chasing over a linked list for memory latency measurement, inspired by lmbench's lat_mem_rd

The read and write implementations use nested loops to avoid modulo overhead — the outer loop counts full buffer passes, the inner loop does sequential access. This gives symmetric read/write performance (unlike the legacy "mem" event which uses vectorized memset).

The chase workload supports configurable buffer size, stride, and pattern. The "random" pattern uses bit-reversed pointer ordering (from lmbench) to defeat hardware prefetchers, while "sequential" uses a simple stride-based chain. Buffer size controls which cache level is stressed.

JSON syntax:
  "memrun": { "type": "chase", "size": 262144, "stride": 64,
              "pattern": "random", "count": 50000000 }
  "memrun": { "type": "read", "size": 10485760, "count": 10485760 }
  "memrun": { "type": "write", "size": 10485760, "count": 10485760 }

The existing "mem" integer event is unchanged for backward compatibility.

Verified on ARM64 with simpleperf showing clear differentiation across workload types in instruction and bus-access stats.