### PR TITLE
Fix SCHED_FLAG_KEEP_PARAMS use for sched_runtime

### DIFF
--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -949,7 +949,7 @@ static void __set_thread_sched_other_attrs(thread_data_t *data,
 					   sched_data_t *sched_data)
 {
 	int ret;
-	struct sched_attr sa_params = {0};
+	struct sched_attr sa_params = {0}, current_sa_params;
 	unsigned int flags = 0;
 	pid_t tid;
 
@@ -979,11 +979,21 @@ static void __set_thread_sched_other_attrs(thread_data_t *data,
 	 * for tasks using a fair.c policy (other than SCHED_IDLE) via
 	 * sched_attr::sched_runtime.
 	 */
-
 	if(sched_data->runtime)
 		sa_params.sched_runtime = sched_data->runtime;
-	else
-		sa_params.sched_flags = SCHED_FLAG_KEEP_PARAMS;
+	else {
+		/* sched_runtime was not requested - keep the current value */
+		ret = sched_getattr(tid, &current_sa_params,
+				    sizeof(struct sched_attr), flags);
+		if (ret) {
+			log_critical("[%d] sched_getattr returned %d",
+				     data->ind, ret);
+			errno = ret;
+			perror("sched_getattr: failed to get SCHED_OTHER attributes");
+			exit(EXIT_FAILURE);
+		}
+		sa_params.sched_runtime = current_sa_params.sched_runtime;
+	}
 
 	ret = sched_setattr(tid, &sa_params, flags);
 	if (ret) {


### PR DESCRIPTION
SCHED_FLAG_KEEP_PARAMS is too coarse-grained for preserving only the sched_runtime value set by system managers since it will also prevent other parameters from being changed. The result is that the SCHED_OTHER nice value can now only be changed when sched_runtime != 0.

Instead, when sched_runtime is not requested by the user, set it to the value read by sched_getattr.

As @deggeman pointed out on the commit, this is a very narrow fix. AFAIK systemd can also set `sched_policy`, `sched_nice`, `sched_priority`, the `RESET_ON_FORK` field in `sched_flags` and uclamp values with cgroup v2. And this is not accounting for other things systemd can control like affinity, NUMA etc.

Maybe we should revisit the strategy for how we decide default values for scheduling parameters? Should everything behave like "if not set by the user, set it to an inherited value"?