### PR TITLE
rt-app: Allow to set only nice or runtime value for SCHED_OTHER/BATCH…

### DIFF
--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -948,12 +948,17 @@ static bool __set_thread_policy_priority(thread_data_t *data,
 static void __set_thread_sched_other_attrs(thread_data_t *data,
 					   sched_data_t *sched_data)
 {
-	int ret;
-	struct sched_attr sa_params = {0};
+	int ret, prio_unchanged;
+	struct sched_attr sa_params = {0}, _sa_params = {0};
 	unsigned int flags = 0;
 	pid_t tid;
 
-	if (sched_data->prio > 19 || sched_data->prio < -20) {
+	prio_unchanged = sched_data->prio == THREAD_PRIORITY_UNCHANGED;
+
+	if (prio_unchanged && !sched_data->runtime)
+		return;
+
+	if (!prio_unchanged && (sched_data->prio > 19 || sched_data->prio < -20)) {
 		log_critical("[%d] sched_setattr %d nice invalid. "
 			     "Valid between -20 and 19",
 			     data->ind, sched_data->prio);
@@ -968,22 +973,35 @@ static void __set_thread_sched_other_attrs(thread_data_t *data,
 		   policy_to_string(sched_data->policy), sched_data->prio,
 		   sched_data->runtime);
 
+	if (prio_unchanged || !sched_data->runtime) {
+		_sa_params.size = sizeof(_sa_params);
+
+		if (sched_getattr(0, &_sa_params, sizeof(_sa_params), 0) == -1) {
+			perror("sched_getattr: failed to get SCHED_OTHER attributes");
+			exit(EXIT_FAILURE);
+		}
+	}
+
 	tid = gettid();
 	sa_params.size = sizeof(struct sched_attr);
 	sa_params.sched_policy = sched_data->policy;
 	sa_params.sched_priority = __sched_priority(data, sched_data);
+
 	/* In the CFS case, sched_data->prio is the NICE value. */
-	sa_params.sched_nice = sched_data->prio;
+	if (!prio_unchanged)
+		sa_params.sched_nice = sched_data->prio;
+	else
+		sa_params.sched_nice = _sa_params.sched_nice;
+
 	/*
 	 * Since Linux v6.12 it is possible to request a custom slice length
 	 * for tasks using a fair.c policy (other than SCHED_IDLE) via
 	 * sched_attr::sched_runtime.
 	 */
-
-	if(sched_data->runtime)
+	if (sched_data->runtime)
 		sa_params.sched_runtime = sched_data->runtime;
 	else
-		sa_params.sched_flags = SCHED_FLAG_KEEP_PARAMS;
+		sa_params.sched_runtime = _sa_params.sched_runtime;
 
 	ret = sched_setattr(tid, &sa_params, flags);
 	if (ret) {
@@ -997,9 +1015,6 @@ static void __set_thread_sched_other_attrs(thread_data_t *data,
 
 static void _set_thread_cfs(thread_data_t *data, sched_data_t *sched_data)
 {
-	/* Priority unchanged => Policy unchanged */
-	if (sched_data->prio == THREAD_PRIORITY_UNCHANGED)
-		return;
 	/*
 	 * In the CFS case, sched_data->prio is the NICE value. As long as the
 	 * policy hasn't changed, there's no need to call

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -111,7 +111,7 @@ static void thread_data_set_unique_name(thread_data_t *tdata, int nforks)
 		tdata->name = strdup(tdata->name);
 	}
 
-	log_notice("thread_data_set_unique_name %d %s", tdata->ind, tdata->name);
+	log_notice("[%d] set unique thread name %s", tdata->ind, tdata->name);
 }
 
 /*
@@ -911,20 +911,6 @@ static int __sched_priority(thread_data_t *data, sched_data_t *sched_data)
 	 return 0;
 }
 
-
-static void __log_policy_priority_change(thread_data_t *data,
-					 sched_data_t *sched_data)
-{
-	log_debug("[%d] setting scheduler %s priority %d", data->ind,
-		  policy_to_string(sched_data->policy),
-		  sched_data->prio);
-
-	log_ftrace(ft_data.marker_fd, FTRACE_ATTRS,
-		   "rtapp_attrs: event=policy policy=%s prio=%d",
-		   policy_to_string(sched_data->policy),
-		   sched_data->prio);
-}
-
 static bool __set_thread_policy_priority(thread_data_t *data,
 					 sched_data_t *sched_data)
 {
@@ -936,6 +922,7 @@ static bool __set_thread_policy_priority(thread_data_t *data,
 	ret = pthread_setschedparam(pthread_self(),
 				    sched_data->policy,
 				    &param);
+
 	if (ret) {
 		log_critical("[%d] pthread_setschedparam returned %d",
 			     data->ind, ret);
@@ -943,6 +930,13 @@ static bool __set_thread_policy_priority(thread_data_t *data,
 		perror("pthread_setschedparam");
 		exit(EXIT_FAILURE);
 	}
+
+	log_debug("[%d] setting scheduler %s priority %d", data->ind,
+		  policy_to_string(sched_data->policy), param.sched_priority);
+
+	log_ftrace(ft_data.marker_fd, FTRACE_ATTRS,
+		   "rtapp_attrs: event=policy policy=%s prio=%d",
+		   policy_to_string(sched_data->policy), param.sched_priority);
 }
 
 static void __set_thread_sched_other_attrs(thread_data_t *data,
@@ -964,14 +958,6 @@ static void __set_thread_sched_other_attrs(thread_data_t *data,
 			     data->ind, sched_data->prio);
 		exit(EXIT_FAILURE);
 	}
-
-	log_debug("[%d] setting scheduler %s nice=%d runtime=%lu",
-		  data->ind, policy_to_string(sched_data->policy),
-		  sched_data->prio, sched_data->runtime);
-	log_ftrace(ft_data.marker_fd, FTRACE_ATTRS,
-		   "rtapp_attrs: event=policy policy=%s nice=%d runtime=%lu",
-		   policy_to_string(sched_data->policy), sched_data->prio,
-		   sched_data->runtime);
 
 	if (prio_unchanged || !sched_data->runtime) {
 		_sa_params.size = sizeof(_sa_params);
@@ -1011,6 +997,15 @@ static void __set_thread_sched_other_attrs(thread_data_t *data,
 		perror("sched_setattr: failed to set SCHED_OTHER attributes");
 		exit(EXIT_FAILURE);
 	}
+
+	log_debug("[%d] setting scheduler %s nice=%d runtime=%llu",
+		  data->ind, policy_to_string(sched_data->policy),
+		  sa_params.sched_nice, sa_params.sched_runtime);
+
+	log_ftrace(ft_data.marker_fd, FTRACE_ATTRS,
+		   "rtapp_attrs: event=policy policy=%s nice=%d runtime=%llu",
+		   policy_to_string(sched_data->policy), sa_params.sched_nice,
+		   sa_params.sched_runtime);
 }
 
 static void _set_thread_cfs(thread_data_t *data, sched_data_t *sched_data)
@@ -1029,8 +1024,6 @@ static void _set_thread_cfs(thread_data_t *data, sched_data_t *sched_data)
 
 	if (sched_data->policy == other || sched_data->policy == batch)
 		__set_thread_sched_other_attrs(data, sched_data);
-
-	__log_policy_priority_change(data, sched_data);
 }
 
 static void _set_thread_rt(thread_data_t *data, sched_data_t *sched_data)
@@ -1040,7 +1033,6 @@ static void _set_thread_rt(thread_data_t *data, sched_data_t *sched_data)
 		return;
 
 	__set_thread_policy_priority(data, sched_data);
-	__log_policy_priority_change(data, sched_data);
 }
 
 /* deadline can't rely on the default __set_thread_policy_priority */
@@ -1221,7 +1213,7 @@ void *thread_body(void *arg)
 
 	t_first = t_zero;
 
-	log_notice("[%d] starting thread ...\n", data->ind);
+	log_notice("[%d] starting thread %s", data->ind, data->name);
 
 	if (opts.logsize)
 		fprintf(data->log_handler, "%s %8s %8s %8s %15s %15s %15s %10s %10s %10s %10s\n",
@@ -1246,10 +1238,6 @@ void *thread_body(void *arg)
 	 * budget as little as possible for the first iteration.
 	 */
 
-	/* Set scheduling policy and print pretty info on stdout */
-	log_notice("[%d] Starting with %s policy with priority %d",
-			data->ind, policy_to_string(data->sched_data->policy),
-			data->sched_data->prio);
 	set_thread_param(data, data->sched_data);
 	set_thread_membind(data, &data->numa_data);
 	set_thread_taskgroup(data, data->taskgroup_data);

--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -848,12 +848,10 @@ static sched_data_t *parse_sched_data(struct json_object *obj, int def_policy)
 	/* Get priority */
 	switch (tmp_data.policy) {
 	case same:
-		prior_def = THREAD_PRIORITY_UNCHANGED;
-		break;
 	case other:
 	case batch:
 	case idle:
-		prior_def = DEFAULT_THREAD_NICE;
+		prior_def = THREAD_PRIORITY_UNCHANGED;
 		break;
 	case fifo:
 	case rr:
@@ -902,14 +900,14 @@ static sched_data_t *parse_sched_data(struct json_object *obj, int def_policy)
 	tmp_data.deadline *= 1000;
 
 	/* Check if we found at least one meaningful scheduler parameter */
-	if (tmp_data.prio != THREAD_PRIORITY_UNCHANGED ||
+	if (def_policy != same || tmp_data.prio != THREAD_PRIORITY_UNCHANGED ||
 	    tmp_data.runtime || tmp_data.period || tmp_data.deadline ||
 	    tmp_data.util_min != -1 || tmp_data.util_max != -1) {
 		sched_data_t *new_data;
 
 		/* At least 1 parameters has been set in the object */
 		new_data = malloc(sizeof(sched_data_t));
-		memcpy( new_data, &tmp_data,sizeof(sched_data_t));
+		memcpy(new_data, &tmp_data, sizeof(sched_data_t));
 
 		log_debug(PIN "key: set scheduler %d with priority %d", new_data->policy, new_data->prio);
 

--- a/src/rt-app_types.h
+++ b/src/rt-app_types.h
@@ -44,7 +44,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #define RTAPP_FTRACE_PATH_LENGTH 256
 
 #define DEFAULT_THREAD_PRIORITY 10
-#define DEFAULT_THREAD_NICE 0
 #define THREAD_PRIORITY_UNCHANGED INT_MAX
 
 #define PATH_LENGTH 256


### PR DESCRIPTION
… tasks

sa_params.sched_flags = SCHED_FLAG_KEEP_PARAMS can't be used to keep the current se.slice value for a task in case it is not specified in its rt-app profile since in this case the nice value which might be in the profile gets ignored too:

Kernel-side sched_setattr retrieves the parameters from the task in case SCHED_FLAG_KEEP_PARAMS is set:

  SYSCALL_DEFINE3(sched_setattr, ...) does:

  if (attr.sched_flags & SCHED_FLAG_KEEP_PARAMS)
    get_params(p, &attr, 0);

So in case either sched_data's prio or runtime is not set, retrieve the task parameters from the kernel to be able to set the value in case it is not specified in sched_data.

Make sure that the sched_data->prio == THREAD_PRIORITY_UNCHANGED can reach __set_thread_sched_other_attrs().