### PR TITLE
rt-app: remove duplicate t_start init

### DIFF
--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -1618,9 +1618,6 @@ int main(int argc, char* argv[])
 	/* Take the beginning time for everything */
 	clock_gettime(CLOCK_MONOTONIC, &t_start);
 
-	/* Sync timer resources with start time */
-	clock_gettime(CLOCK_MONOTONIC, &t_start);
-
 	/* Start the use case */
 	int ind = 0;
 	for (i = 0; i < opts.num_tasks; i++) {


### PR DESCRIPTION
t_start is init twice back to back. The 2nd one refers to the timers which use t_zero that is initialized by 1st thread.